### PR TITLE
[AArch64][LFI] Consolidate LFI metadata and automate addressing-mode/base mapping

### DIFF
--- a/llvm/docs/LFI.rst
+++ b/llvm/docs/LFI.rst
@@ -115,8 +115,6 @@ Example:
 Compiler Options
 ++++++++++++++++
 
-**Note**: these options are not yet implemented.
-
 The LFI target has several configuration options, specified via ``-mattr=``:
 
 * ``+no-lfi-loads``: Disable sandboxing for load instructions (stores-only mode).
@@ -197,8 +195,6 @@ require any rewrite.
 Memory accesses
 ~~~~~~~~~~~~~~~
 
-**Note**: not yet implemented.
-
 Memory accesses are rewritten to use the ``[x27, wM, uxtw]`` addressing mode if
 it is available, which is automatically safe. Otherwise, rewrites fall back to
 using ``x28`` along with an instruction to safely load it with the target
@@ -278,8 +274,6 @@ address.
 
 Stack pointer modification
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-**Note**: not yet implemented.
 
 When the stack pointer is modified, we write the modified value to a temporary,
 before moving it back into ``sp`` with a safe ``add``.

--- a/llvm/docs/LFI.rst
+++ b/llvm/docs/LFI.rst
@@ -166,7 +166,7 @@ In the following assembly rewrites, some shorthand is used.
 * ``xN`` or ``wN``: refers to any general-purpose non-reserved register.
 * ``{a,b,c}``: matches any of ``a``, ``b``, or ``c``.
 * ``LDSTr``: a load/store instruction that supports register-register addressing modes, with one source/destination register.
-* ``LDSTx``: a load/store instruction not matched by ``LDSTr``.
+* ``LDSTx``: a load/store instruction not matched by ``LDSTr``. This covers load/store pairs (``ldp``/``stp``), SIMD load/stores (``ld1``, ``st1``, ...), atomics, exclusives, load/store-release, and unscaled (``ldur``/``stur``) forms. These instructions have a more limited set of addressing modes than ``LDSTr``.
 
 Control flow
 ~~~~~~~~~~~~

--- a/llvm/lib/Target/AArch64/AArch64.td
+++ b/llvm/lib/Target/AArch64/AArch64.td
@@ -51,6 +51,12 @@ def AArch64InstrInfo : InstrInfo;
 include "AArch64SystemOperands.td"
 
 //===----------------------------------------------------------------------===//
+// LFI rewriter metadata consumed by AArch64MCLFIRewriter.
+//===----------------------------------------------------------------------===//
+
+include "AArch64LFI.td"
+
+//===----------------------------------------------------------------------===//
 // AArch64 Processors supported.
 //
 

--- a/llvm/lib/Target/AArch64/AArch64.td
+++ b/llvm/lib/Target/AArch64/AArch64.td
@@ -51,7 +51,8 @@ def AArch64InstrInfo : InstrInfo;
 include "AArch64SystemOperands.td"
 
 //===----------------------------------------------------------------------===//
-// LFI rewriter metadata consumed by AArch64MCLFIRewriter.
+// LFI rewriter metadata consumed by AArch64MCLFIRewriter. Must follow
+// AArch64SystemOperands.td due to use of SearchableTable.td.
 //===----------------------------------------------------------------------===//
 
 include "AArch64LFI.td"

--- a/llvm/lib/Target/AArch64/AArch64Features.td
+++ b/llvm/lib/Target/AArch64/AArch64Features.td
@@ -1079,6 +1079,11 @@ def FeatureHardenSlsNoComdat : SubtargetFeature<"harden-sls-nocomdat",
   "Generate thunk code for SLS mitigation in the normal text section">;
 
 
+def FeatureNoLFILoads : SubtargetFeature<"no-lfi-loads", "NoLFILoads", "true",
+  "Disable LFI sandboxing for load instructions">;
+def FeatureNoLFIStores : SubtargetFeature<"no-lfi-stores", "NoLFIStores", "true",
+  "Disable LFI sandboxing for store instructions">;
+
 // Only intended to be used by disassemblers.
 def FeatureAll
     : SubtargetFeature<"all", "IsAll", "true", "Enable all instructions">;

--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -80,6 +80,9 @@ def SMEMatrixTileD : SMEMatrixTypeEnum<4>;
 def SMEMatrixTileQ : SMEMatrixTypeEnum<5>;
 def SMEMatrixArray : SMEMatrixTypeEnum<6>;
 
+
+include "AArch64LFIInstrFormats.td"
+
 // AArch64 Instruction Format
 class AArch64Inst<Format f, string cstr> : Instruction {
   field bits<32> Inst; // Instruction encoding.
@@ -3843,7 +3846,12 @@ def uimm12s16 : uimm12_scaled<16>;
 
 class BaseLoadStoreUI<bits<2> sz, bit V, bits<2> opc, dag oops, dag iops,
                       string asm, list<dag> pattern>
-    : I<oops, iops, asm, "\t$Rt, [$Rn, $offset]", "", pattern> {
+    : I<oops, iops, asm, "\t$Rt, [$Rn, $offset]", "", pattern>,
+      LFIScalarVariant {
+  let IsLFIMem = 1;
+  let BaseIdx = 1;
+  let OffsetIdx = 2;
+  let HasOffset = 1;
   bits<5> Rt;
 
   bits<5> Rn;
@@ -4081,7 +4089,8 @@ def ro128 : ROAddrMode<ro_Windexed128, ro_Xindexed128, ro_Wextend128,
 
 class LoadStore8RO<bits<2> sz, bit V, bits<2> opc, string asm, dag ins,
                    dag outs, list<dag> pat>
-    : I<ins, outs, asm, "\t$Rt, [$Rn, $Rm, $extend]", "", pat> {
+    : I<ins, outs, asm, "\t$Rt, [$Rn, $Rm, $extend]", "", pat>,
+      LFILoadStoreRO<sz, V> {
   bits<5> Rt;
   bits<5> Rn;
   bits<5> Rm;
@@ -4160,7 +4169,8 @@ multiclass Store8RO<bits<2> sz, bit V, bits<2> opc, DAGOperand regtype,
 
 class LoadStore16RO<bits<2> sz, bit V, bits<2> opc, string asm, dag ins,
                     dag outs, list<dag> pat>
-    : I<ins, outs, asm, "\t$Rt, [$Rn, $Rm, $extend]", "", pat> {
+    : I<ins, outs, asm, "\t$Rt, [$Rn, $Rm, $extend]", "", pat>,
+      LFILoadStoreRO<sz, V> {
   bits<5> Rt;
   bits<5> Rn;
   bits<5> Rm;
@@ -4232,7 +4242,8 @@ multiclass Store16RO<bits<2> sz, bit V, bits<2> opc, DAGOperand regtype,
 
 class LoadStore32RO<bits<2> sz, bit V, bits<2> opc, string asm, dag ins,
                     dag outs, list<dag> pat>
-    : I<ins, outs, asm, "\t$Rt, [$Rn, $Rm, $extend]", "", pat> {
+    : I<ins, outs, asm, "\t$Rt, [$Rn, $Rm, $extend]", "", pat>,
+      LFILoadStoreRO<sz, V> {
   bits<5> Rt;
   bits<5> Rn;
   bits<5> Rm;
@@ -4304,7 +4315,8 @@ multiclass Store32RO<bits<2> sz, bit V, bits<2> opc, DAGOperand regtype,
 
 class LoadStore64RO<bits<2> sz, bit V, bits<2> opc, string asm, dag ins,
                     dag outs, list<dag> pat>
-    : I<ins, outs, asm, "\t$Rt, [$Rn, $Rm, $extend]", "", pat> {
+    : I<ins, outs, asm, "\t$Rt, [$Rn, $Rm, $extend]", "", pat>,
+      LFILoadStoreRO<sz, V> {
   bits<5> Rt;
   bits<5> Rn;
   bits<5> Rm;
@@ -4376,7 +4388,8 @@ multiclass Store64RO<bits<2> sz, bit V, bits<2> opc, DAGOperand regtype,
 
 class LoadStore128RO<bits<2> sz, bit V, bits<2> opc, string asm, dag ins,
                      dag outs, list<dag> pat>
-    : I<ins, outs, asm, "\t$Rt, [$Rn, $Rm, $extend]", "", pat> {
+    : I<ins, outs, asm, "\t$Rt, [$Rn, $Rm, $extend]", "", pat>,
+      LFILoadStoreRO<sz, V> {
   bits<5> Rt;
   bits<5> Rn;
   bits<5> Rm;
@@ -4446,7 +4459,9 @@ let mayLoad = 0, mayStore = 0, hasSideEffects = 1 in
 class BasePrefetchRO<bits<2> sz, bit V, bits<2> opc, dag outs, dag ins,
                      string asm, list<dag> pat>
     : I<outs, ins, asm, "\t$Rt, [$Rn, $Rm, $extend]", "", pat>,
+      LFILoadStoreRO<sz, V>,
       Sched<[WriteLD]> {
+  let Log2Size = 3;
   bits<5> Rt;
   bits<5> Rn;
   bits<5> Rm;
@@ -4653,7 +4668,14 @@ multiclass StoreUnprivileged<bits<2> sz, bit V, bits<2> opc,
 
 class BaseLoadStorePreIdx<bits<2> sz, bit V, bits<2> opc, dag oops, dag iops,
                           string asm, string cstr, list<dag> pat>
-    : I<oops, iops, asm, "\t$Rt, [$Rn, $offset]!", cstr, pat> {
+    : I<oops, iops, asm, "\t$Rt, [$Rn, $offset]!", cstr, pat>,
+      LFIScalarVariant {
+  let IsLFIMem = 1;
+  let BaseIdx = 2;
+  let OffsetIdx = 3;
+  let HasOffset = 1;
+  let IsPrePost = 1;
+
   bits<5> Rt;
   bits<5> Rn;
   bits<9> offset;
@@ -4699,7 +4721,14 @@ class StorePreIdx<bits<2> sz, bit V, bits<2> opc, RegisterOperand regtype,
 
 class BaseLoadStorePostIdx<bits<2> sz, bit V, bits<2> opc, dag oops, dag iops,
                           string asm, string cstr, list<dag> pat>
-    : I<oops, iops, asm, "\t$Rt, [$Rn], $offset", cstr, pat> {
+    : I<oops, iops, asm, "\t$Rt, [$Rn], $offset", cstr, pat>,
+      LFIScalarVariant {
+  let IsLFIMem = 1;
+  let BaseIdx = 2;
+  let OffsetIdx = 3;
+  let HasOffset = 1;
+  let IsPrePost = 1;
+
   bits<5> Rt;
   bits<5> Rn;
   bits<9> offset;
@@ -4748,7 +4777,13 @@ class StorePostIdx<bits<2> sz, bit V, bits<2> opc, RegisterOperand regtype,
 
 class BaseLoadStorePairOffset<bits<2> opc, bit V, bit L, dag oops, dag iops,
                               string asm>
-    : I<oops, iops, asm, "\t$Rt, $Rt2, [$Rn, $offset]", "", []> {
+    : I<oops, iops, asm, "\t$Rt, $Rt2, [$Rn, $offset]", "", []>,
+      LFIInstruction {
+  let LFIInst = !cast<Instruction>(NAME);
+  let IsLFIMem = 1;
+  let BaseIdx = 2;
+  let OffsetIdx = 3;
+  let HasOffset = 1;
   bits<5> Rt;
   bits<5> Rt2;
   bits<5> Rn;
@@ -4839,7 +4874,24 @@ multiclass StoreAcquirePairOffset<bits<4> opc, string asm> {
 // (pre-indexed)
 class BaseLoadStorePairPreIdx<bits<2> opc, bit V, bit L, dag oops, dag iops,
                               string asm>
-    : I<oops, iops, asm, "\t$Rt, $Rt2, [$Rn, $offset]!", "$Rn = $wback,@earlyclobber $wback", []> {
+    : I<oops, iops, asm, "\t$Rt, $Rt2, [$Rn, $offset]!", "$Rn = $wback,@earlyclobber $wback", []>,
+      LFIInstruction {
+  let LFIInst = !cast<Instruction>(NAME);
+  let IsLFIMem = 1;
+  let BaseIdx = 3;
+  let OffsetIdx = 4;
+  let HasOffset = 1;
+  let IsPrePost = 1;
+
+  let HasPairVariant = 1;
+  let IsPre = 1;
+  let BaseInst = !cast<Instruction>(!subst("pre", "i", NAME));
+  let Scale = !cond(
+    !ne(NAME, !subst("LDPQ", "", !subst("STPQ", "", NAME))) : 16,
+    !ne(NAME, !subst("LDPD", "", !subst("STPD", "", NAME))) : 8,
+    !ne(NAME, !subst("LDPX", "", !subst("STPX", "", NAME))) : 8,
+    1 : 4
+  );
   bits<5> Rt;
   bits<5> Rt2;
   bits<5> Rn;
@@ -4880,7 +4932,24 @@ class StorePairPreIdx<bits<2> opc, bit V, RegisterOperand regtype,
 
 class BaseLoadStorePairPostIdx<bits<2> opc, bit V, bit L, dag oops, dag iops,
                               string asm>
-    : I<oops, iops, asm, "\t$Rt, $Rt2, [$Rn], $offset", "$Rn = $wback,@earlyclobber $wback", []> {
+    : I<oops, iops, asm, "\t$Rt, $Rt2, [$Rn], $offset", "$Rn = $wback,@earlyclobber $wback", []>,
+      LFIInstruction {
+  let LFIInst = !cast<Instruction>(NAME);
+  let IsLFIMem = 1;
+  let BaseIdx = 3;
+  let OffsetIdx = 4;
+  let HasOffset = 1;
+  let IsPrePost = 1;
+
+  let HasPairVariant = 1;
+  let IsPre = 0;
+  let BaseInst = !cast<Instruction>(!subst("post", "i", NAME));
+  let Scale = !cond(
+    !ne(NAME, !subst("LDPQ", "", !subst("STPQ", "", NAME))) : 16,
+    !ne(NAME, !subst("LDPD", "", !subst("STPD", "", NAME))) : 8,
+    !ne(NAME, !subst("LDPX", "", !subst("STPX", "", NAME))) : 8,
+    1 : 4
+  );
   bits<5> Rt;
   bits<5> Rt2;
   bits<5> Rn;
@@ -10969,7 +11038,11 @@ multiclass SIMDVectorLShiftLongBHSD<bit U, bits<5> opc, string asm,
 
 class BaseSIMDLdSt<bit Q, bit L, bits<4> opcode, bits<2> size,
                    string asm, dag oops, dag iops, list<dag> pattern>
-  : I<oops, iops, asm, "\t$Vt, [$Rn]", "", pattern> {
+  : I<oops, iops, asm, "\t$Vt, [$Rn]", "", pattern>,
+    LFIInstruction {
+  let LFIInst = !cast<Instruction>(NAME);
+  let IsLFIMem = 1;
+  let BaseIdx = 1;
   bits<5> Vt;
   bits<5> Rn;
   let Inst{31} = 0;
@@ -10985,7 +11058,27 @@ class BaseSIMDLdSt<bit Q, bit L, bits<4> opcode, bits<2> size,
 
 class BaseSIMDLdStPost<bit Q, bit L, bits<4> opcode, bits<2> size,
                        string asm, dag oops, dag iops>
-  : I<oops, iops, asm, "\t$Vt, [$Rn], $Xm", "$Rn = $wback", []> {
+  : I<oops, iops, asm, "\t$Vt, [$Rn], $Xm", "$Rn = $wback", []>,
+    LFIInstruction {
+  let LFIInst = !cast<Instruction>(NAME);
+  let IsLFIMem = 1;
+  let BaseIdx = 2;
+  let OffsetIdx = 3;
+  let HasOffset = 1;
+  let IsPrePost = 1;
+
+  let HasSIMDPost = 1;
+  let BaseInst = !cast<Instruction>(!subst("_POST", "", NAME));
+  let NaturalOffset = !mul(
+    !cond(
+      !ne(NAME, !subst("One", "", NAME)) : 1,
+      !ne(NAME, !subst("Two", "", NAME)) : 2,
+      !ne(NAME, !subst("Three", "", NAME)) : 3,
+      !ne(NAME, !subst("Four", "", NAME)) : 4,
+      1 : 1
+    ),
+    !cond(Q : 16, 1 : 8)
+  );
   bits<5> Vt;
   bits<5> Rn;
   bits<5> Xm;
@@ -11307,7 +11400,11 @@ class BaseSIMDLdR<bit Q, bit R, bits<3> opcode, bit S, bits<2> size, string asm,
                   DAGOperand listtype>
   : BaseSIMDLdStSingle<1, R, opcode, asm, "\t$Vt, [$Rn]", "",
                        (outs listtype:$Vt), (ins GPR64sp:$Rn),
-                       []> {
+                       []>,
+    LFIInstruction {
+  let LFIInst = !cast<Instruction>(NAME);
+  let IsLFIMem = 1;
+  let BaseIdx = 1;
   let Inst{30} = Q;
   let Inst{23} = 0;
   let Inst{20-16} = 0b00000;
@@ -11320,7 +11417,33 @@ class BaseSIMDLdRPost<bit Q, bit R, bits<3> opcode, bit S, bits<2> size,
   : BaseSIMDLdStSingle<1, R, opcode, asm, "\t$Vt, [$Rn], $Xm",
                        "$Rn = $wback",
                        (outs GPR64sp:$wback, listtype:$Vt),
-                       (ins GPR64sp:$Rn, GPR64pi:$Xm), []> {
+                       (ins GPR64sp:$Rn, GPR64pi:$Xm), []>,
+    LFIInstruction {
+  let LFIInst = !cast<Instruction>(NAME);
+  let IsLFIMem = 1;
+  let BaseIdx = 2;
+  let OffsetIdx = 3;
+  let HasOffset = 1;
+  let IsPrePost = 1;
+
+  let HasSIMDPost = 1;
+  let BaseInst = !cast<Instruction>(!subst("_POST", "", NAME));
+  let NaturalOffset = !mul(
+    !cond(
+      !ne(NAME, !subst("LD1R", "", NAME)) : 1,
+      !ne(NAME, !subst("LD2R", "", NAME)) : 2,
+      !ne(NAME, !subst("LD3R", "", NAME)) : 3,
+      !ne(NAME, !subst("LD4R", "", NAME)) : 4,
+      1 : 1
+    ),
+    !cond(
+      !ne(NAME, !subst("b_POST", "", NAME)) : 1,
+      !ne(NAME, !subst("h_POST", "", NAME)) : 2,
+      !ne(NAME, !subst("s_POST", "", NAME)) : 4,
+      !ne(NAME, !subst("d_POST", "", NAME)) : 8,
+      1 : 1
+    )
+  );
   bits<5> Xm;
   let Inst{30} = Q;
   let Inst{23} = 1;
@@ -11428,7 +11551,8 @@ multiclass SIMDLdR<bit R, bits<3> opcode, bit S, string asm, string Count,
 class SIMDLdStSingleB<bit L, bit R, bits<3> opcode, string asm,
                       dag oops, dag iops, list<dag> pattern>
   : BaseSIMDLdStSingle<L, R, opcode, asm, "\t$Vt$idx, [$Rn]", "", oops, iops,
-                       pattern> {
+                       pattern>,
+    LFILaneBaseStore {
   // idx encoded in Q:S:size fields.
   bits<4> idx;
   let Inst{30} = idx{3};
@@ -11440,7 +11564,8 @@ class SIMDLdStSingleB<bit L, bit R, bits<3> opcode, string asm,
 class SIMDLdStSingleBTied<bit L, bit R, bits<3> opcode, string asm,
                       dag oops, dag iops, list<dag> pattern>
   : BaseSIMDLdStSingleTied<L, R, opcode, asm, "\t$Vt$idx, [$Rn]", "",
-                           oops, iops, pattern> {
+                           oops, iops, pattern>,
+    LFILaneBaseLoadTied {
   // idx encoded in Q:S:size fields.
   bits<4> idx;
   let Inst{30} = idx{3};
@@ -11452,7 +11577,8 @@ class SIMDLdStSingleBTied<bit L, bit R, bits<3> opcode, string asm,
 class SIMDLdStSingleBPost<bit L, bit R, bits<3> opcode, string asm,
                           dag oops, dag iops>
   : BaseSIMDLdStSingle<L, R, opcode, asm, "\t$Vt$idx, [$Rn], $Xm",
-                       "$Rn = $wback", oops, iops, []> {
+                       "$Rn = $wback", oops, iops, []>,
+    LFILanePostStore<1> {
   // idx encoded in Q:S:size fields.
   bits<4> idx;
   bits<5> Xm;
@@ -11465,7 +11591,8 @@ class SIMDLdStSingleBPost<bit L, bit R, bits<3> opcode, string asm,
 class SIMDLdStSingleBTiedPost<bit L, bit R, bits<3> opcode, string asm,
                           dag oops, dag iops>
   : BaseSIMDLdStSingleTied<L, R, opcode, asm, "\t$Vt$idx, [$Rn], $Xm",
-                           "$Rn = $wback", oops, iops, []> {
+                           "$Rn = $wback", oops, iops, []>,
+    LFILanePostLoadTied<1> {
   // idx encoded in Q:S:size fields.
   bits<4> idx;
   bits<5> Xm;
@@ -11479,7 +11606,8 @@ class SIMDLdStSingleBTiedPost<bit L, bit R, bits<3> opcode, string asm,
 class SIMDLdStSingleH<bit L, bit R, bits<3> opcode, bit size, string asm,
                       dag oops, dag iops, list<dag> pattern>
   : BaseSIMDLdStSingle<L, R, opcode, asm, "\t$Vt$idx, [$Rn]", "", oops, iops,
-                       pattern> {
+                       pattern>,
+    LFILaneBaseStore {
   // idx encoded in Q:S:size<1> fields.
   bits<3> idx;
   let Inst{30} = idx{2};
@@ -11492,7 +11620,8 @@ class SIMDLdStSingleH<bit L, bit R, bits<3> opcode, bit size, string asm,
 class SIMDLdStSingleHTied<bit L, bit R, bits<3> opcode, bit size, string asm,
                       dag oops, dag iops, list<dag> pattern>
   : BaseSIMDLdStSingleTied<L, R, opcode, asm, "\t$Vt$idx, [$Rn]", "",
-                           oops, iops, pattern> {
+                           oops, iops, pattern>,
+    LFILaneBaseLoadTied {
   // idx encoded in Q:S:size<1> fields.
   bits<3> idx;
   let Inst{30} = idx{2};
@@ -11506,7 +11635,8 @@ class SIMDLdStSingleHTied<bit L, bit R, bits<3> opcode, bit size, string asm,
 class SIMDLdStSingleHPost<bit L, bit R, bits<3> opcode, bit size, string asm,
                           dag oops, dag iops>
   : BaseSIMDLdStSingle<L, R, opcode, asm, "\t$Vt$idx, [$Rn], $Xm",
-                       "$Rn = $wback", oops, iops, []> {
+                       "$Rn = $wback", oops, iops, []>,
+    LFILanePostStore<2> {
   // idx encoded in Q:S:size<1> fields.
   bits<3> idx;
   bits<5> Xm;
@@ -11520,7 +11650,8 @@ class SIMDLdStSingleHPost<bit L, bit R, bits<3> opcode, bit size, string asm,
 class SIMDLdStSingleHTiedPost<bit L, bit R, bits<3> opcode, bit size, string asm,
                           dag oops, dag iops>
   : BaseSIMDLdStSingleTied<L, R, opcode, asm, "\t$Vt$idx, [$Rn], $Xm",
-                           "$Rn = $wback", oops, iops, []> {
+                           "$Rn = $wback", oops, iops, []>,
+    LFILanePostLoadTied<2> {
   // idx encoded in Q:S:size<1> fields.
   bits<3> idx;
   bits<5> Xm;
@@ -11534,7 +11665,8 @@ class SIMDLdStSingleHTiedPost<bit L, bit R, bits<3> opcode, bit size, string asm
 class SIMDLdStSingleS<bit L, bit R, bits<3> opcode, bits<2> size, string asm,
                       dag oops, dag iops, list<dag> pattern>
   : BaseSIMDLdStSingle<L, R, opcode, asm, "\t$Vt$idx, [$Rn]", "", oops, iops,
-                       pattern> {
+                       pattern>,
+    LFILaneBaseStore {
   // idx encoded in Q:S fields.
   bits<2> idx;
   let Inst{30} = idx{1};
@@ -11546,7 +11678,8 @@ class SIMDLdStSingleS<bit L, bit R, bits<3> opcode, bits<2> size, string asm,
 class SIMDLdStSingleSTied<bit L, bit R, bits<3> opcode, bits<2> size, string asm,
                       dag oops, dag iops, list<dag> pattern>
   : BaseSIMDLdStSingleTied<L, R, opcode, asm, "\t$Vt$idx, [$Rn]", "",
-                           oops, iops, pattern> {
+                           oops, iops, pattern>,
+    LFILaneBaseLoadTied {
   // idx encoded in Q:S fields.
   bits<2> idx;
   let Inst{30} = idx{1};
@@ -11558,7 +11691,8 @@ class SIMDLdStSingleSTied<bit L, bit R, bits<3> opcode, bits<2> size, string asm
 class SIMDLdStSingleSPost<bit L, bit R, bits<3> opcode, bits<2> size,
                           string asm, dag oops, dag iops>
   : BaseSIMDLdStSingle<L, R, opcode, asm, "\t$Vt$idx, [$Rn], $Xm",
-                       "$Rn = $wback", oops, iops, []> {
+                       "$Rn = $wback", oops, iops, []>,
+    LFILanePostStore<4> {
   // idx encoded in Q:S fields.
   bits<2> idx;
   bits<5> Xm;
@@ -11571,7 +11705,8 @@ class SIMDLdStSingleSPost<bit L, bit R, bits<3> opcode, bits<2> size,
 class SIMDLdStSingleSTiedPost<bit L, bit R, bits<3> opcode, bits<2> size,
                           string asm, dag oops, dag iops>
   : BaseSIMDLdStSingleTied<L, R, opcode, asm, "\t$Vt$idx, [$Rn], $Xm",
-                           "$Rn = $wback", oops, iops, []> {
+                           "$Rn = $wback", oops, iops, []>,
+    LFILanePostLoadTied<4> {
   // idx encoded in Q:S fields.
   bits<2> idx;
   bits<5> Xm;
@@ -11584,7 +11719,8 @@ class SIMDLdStSingleSTiedPost<bit L, bit R, bits<3> opcode, bits<2> size,
 class SIMDLdStSingleD<bit L, bit R, bits<3> opcode, bits<2> size, string asm,
                       dag oops, dag iops, list<dag> pattern>
   : BaseSIMDLdStSingle<L, R, opcode, asm, "\t$Vt$idx, [$Rn]", "", oops, iops,
-                       pattern> {
+                       pattern>,
+    LFILaneBaseStore {
   // idx encoded in Q field.
   bits<1> idx;
   let Inst{30} = idx;
@@ -11596,7 +11732,8 @@ class SIMDLdStSingleD<bit L, bit R, bits<3> opcode, bits<2> size, string asm,
 class SIMDLdStSingleDTied<bit L, bit R, bits<3> opcode, bits<2> size, string asm,
                       dag oops, dag iops, list<dag> pattern>
   : BaseSIMDLdStSingleTied<L, R, opcode, asm, "\t$Vt$idx, [$Rn]", "",
-                           oops, iops, pattern> {
+                           oops, iops, pattern>,
+    LFILaneBaseLoadTied {
   // idx encoded in Q field.
   bits<1> idx;
   let Inst{30} = idx;
@@ -11608,7 +11745,8 @@ class SIMDLdStSingleDTied<bit L, bit R, bits<3> opcode, bits<2> size, string asm
 class SIMDLdStSingleDPost<bit L, bit R, bits<3> opcode, bits<2> size,
                           string asm, dag oops, dag iops>
   : BaseSIMDLdStSingle<L, R, opcode, asm, "\t$Vt$idx, [$Rn], $Xm",
-                       "$Rn = $wback", oops, iops, []> {
+                       "$Rn = $wback", oops, iops, []>,
+    LFILanePostStore<8> {
   // idx encoded in Q field.
   bits<1> idx;
   bits<5> Xm;
@@ -11621,7 +11759,8 @@ class SIMDLdStSingleDPost<bit L, bit R, bits<3> opcode, bits<2> size,
 class SIMDLdStSingleDTiedPost<bit L, bit R, bits<3> opcode, bits<2> size,
                           string asm, dag oops, dag iops>
   : BaseSIMDLdStSingleTied<L, R, opcode, asm, "\t$Vt$idx, [$Rn], $Xm",
-                           "$Rn = $wback", oops, iops, []> {
+                           "$Rn = $wback", oops, iops, []>,
+    LFILanePostLoadTied<8> {
   // idx encoded in Q field.
   bits<1> idx;
   bits<5> Xm;

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -16,6 +16,7 @@
 #include "AArch64PointerAuth.h"
 #include "AArch64Subtarget.h"
 #include "MCTargetDesc/AArch64AddressingModes.h"
+#include "MCTargetDesc/AArch64MCLFIRewriter.h"
 #include "MCTargetDesc/AArch64MCTargetDesc.h"
 #include "Utils/AArch64BaseInfo.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -129,14 +130,39 @@ static std::optional<unsigned> getLFIInstSizeInBytes(const MachineInstr &MI) {
     if (MI.getOperand(0).getReg() != AArch64::LR)
       return 8;
     return 4;
+  case AArch64::SYSxt:
+    // VA-based DC/IC ops (op1=3, Cn=7, op2=1) expand to 2 instructions.
+    if (MI.getOperand(0).getImm() == 3 && MI.getOperand(1).getImm() == 7 &&
+        MI.getOperand(3).getImm() == 1)
+      return 8;
+    return std::nullopt;
   default:
     break;
   }
 
-  // Instructions that explicitly modify LR expand to 2 instructions.
+  // Instructions that explicitly modify LR get an extra LR mask.
+  bool ModifiesLR = false;
   for (const MachineOperand &MO : MI.explicit_operands())
-    if (MO.isReg() && MO.isDef() && MO.getReg() == AArch64::LR)
-      return 8;
+    if (MO.isReg() && MO.isDef() && MO.getReg() == AArch64::LR) {
+      ModifiesLR = true;
+      break;
+    }
+
+  // Memory accesses expand to a base-register guard plus the rewritten access
+  // (8 bytes), with an extra base-register update for pre/post-index forms (12
+  // bytes total). If the access also defines LR, an LR mask is appended (+4
+  // bytes). Depending on additional optimizations that the rewriter performs,
+  // this may be an overestimate.
+  if (MI.mayLoadOrStore()) {
+    unsigned Size = isLFIPrePostMemAccess(MI.getOpcode()) ? 12 : 8;
+    if (ModifiesLR)
+      Size += 4;
+    return Size;
+  }
+
+  // Non-memory instructions that modify LR expand to 2 instructions.
+  if (ModifiesLR)
+    return 8;
 
   // Default case: instructions that don't cause expansion.
   // - TP accesses in LFI are a single load/store, so no expansion.

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -140,13 +140,17 @@ static std::optional<unsigned> getLFIInstSizeInBytes(const MachineInstr &MI) {
     break;
   }
 
-  // Instructions that explicitly modify LR get an extra LR mask.
+  // Detect instructions that explicitly define SP or LR.
   bool ModifiesLR = false;
-  for (const MachineOperand &MO : MI.explicit_operands())
-    if (MO.isReg() && MO.isDef() && MO.getReg() == AArch64::LR) {
+  bool ModifiesSP = false;
+  for (const MachineOperand &MO : MI.defs()) {
+    if (!MO.isReg())
+      continue;
+    if (MO.getReg() == AArch64::LR)
       ModifiesLR = true;
-      break;
-    }
+    else if (MO.getReg() == AArch64::SP)
+      ModifiesSP = true;
+  }
 
   // Memory accesses expand to a base-register guard plus the rewritten access
   // (8 bytes), with an extra base-register update for pre/post-index forms (12
@@ -159,6 +163,10 @@ static std::optional<unsigned> getLFIInstSizeInBytes(const MachineInstr &MI) {
       Size += 4;
     return Size;
   }
+
+  // SP modification expands to 2 instructions.
+  if (ModifiesSP)
+    return 8;
 
   // Non-memory instructions that modify LR expand to 2 instructions.
   if (ModifiesLR)

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -164,12 +164,8 @@ static std::optional<unsigned> getLFIInstSizeInBytes(const MachineInstr &MI) {
     return Size;
   }
 
-  // SP modification expands to 2 instructions.
-  if (ModifiesSP)
-    return 8;
-
-  // Non-memory instructions that modify LR expand to 2 instructions.
-  if (ModifiesLR)
+  // Non memory operations that modify LR or SP expand to 2 instructions.
+  if (ModifiesSP || ModifiesLR)
     return 8;
 
   // Default case: instructions that don't cause expansion.

--- a/llvm/lib/Target/AArch64/AArch64LFI.td
+++ b/llvm/lib/Target/AArch64/AArch64LFI.td
@@ -1,0 +1,469 @@
+//===-- AArch64LFI.td - LFI rewriter metadata --------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Per-opcode metadata consumed by AArch64MCLFIRewriter. The rewriter queries
+// four generated lookup tables:
+//
+// * lookupLFIVariantByOpcode: scalar load/store addressing-mode info
+//   (ui/roW/roX/pre/post + log2 element size + cross-reference to the RoW
+//   variant).
+//
+// * lookupPairVariantByOpcode: LDP/STP pre/post-index info (base opcode +
+//   scale + pre vs. post).
+//
+// * lookupSIMDPostByOpcode: SIMD post-index info (base opcode + natural byte
+//   offset).
+//
+// * lookupMemInfoByOpcode: generic operand-layout info used by the base
+//   load/store rewriter (base/offset operand indices, IsPrePost, IsLiteral).
+//
+//===----------------------------------------------------------------------===//
+
+// LFI addressing-mode enumeration (matches the rewriter's logical view).
+// Values are exposed to C++ as plain integers.
+class LFIAddrMode<int v> { int Value = v; }
+def LFI_AM_Ui   : LFIAddrMode<0>;
+def LFI_AM_RoW  : LFIAddrMode<1>;
+def LFI_AM_RoX  : LFIAddrMode<2>;
+def LFI_AM_Pre  : LFIAddrMode<3>;
+def LFI_AM_Post : LFIAddrMode<4>;
+
+//===----------------------------------------------------------------------===//
+// LFIVariant - scalar load/store variants
+//
+// One record per (family, addressing mode) combination. RoWInst is the
+// matching RoW variant of the same family.
+//===----------------------------------------------------------------------===//
+
+class LFIVariant<Instruction inst, bits<3> addrMode, bits<3> log2Size,
+                 Instruction roWInst> {
+  Instruction Inst     = inst;
+  bits<3>     AddrMode = addrMode;
+  bits<3>     Log2Size = log2Size;
+  Instruction RoWInst  = roWInst;
+}
+
+def LFIVariantTable : GenericTable {
+  let FilterClass    = "LFIVariant";
+  let CppTypeName    = "LFIVariantEntry";
+  let Fields         = ["Inst", "AddrMode", "Log2Size", "RoWInst"];
+  let PrimaryKey     = ["Inst"];
+  let PrimaryKeyName = "lookupLFIVariantByOpcode";
+}
+
+//===----------------------------------------------------------------------===//
+// PairVariant - LDP/STP pre/post-index entries
+//===----------------------------------------------------------------------===//
+
+class PairVariant<Instruction inst, bit isPre, bits<5> scale,
+                  Instruction baseInst> {
+  Instruction Inst     = inst;
+  bit         IsPre    = isPre;
+  bits<5>     Scale    = scale;
+  Instruction BaseInst = baseInst;
+}
+
+def PairVariantTable : GenericTable {
+  let FilterClass    = "PairVariant";
+  let CppTypeName    = "PairVariantEntry";
+  let Fields         = ["Inst", "IsPre", "Scale", "BaseInst"];
+  let PrimaryKey     = ["Inst"];
+  let PrimaryKeyName = "lookupPairVariantByOpcode";
+}
+
+//===----------------------------------------------------------------------===//
+// SIMDPost - SIMD post-index entries (multi/lane-load/lane-store).
+//===----------------------------------------------------------------------===//
+
+class SIMDPost<Instruction inst, bits<7> naturalOffset,
+               Instruction baseInst> {
+  Instruction Inst          = inst;
+  bits<7>     NaturalOffset = naturalOffset;
+  Instruction BaseInst      = baseInst;
+}
+
+def SIMDPostTable : GenericTable {
+  let FilterClass    = "SIMDPost";
+  let CppTypeName    = "SIMDPostEntry";
+  let Fields         = ["Inst", "NaturalOffset", "BaseInst"];
+  let PrimaryKey     = ["Inst"];
+  let PrimaryKeyName = "lookupSIMDPostByOpcode";
+}
+
+//===----------------------------------------------------------------------===//
+// MemInfo - per-opcode operand layout for the base load/store rewriter.
+//
+// HasOffset = 0 means OffsetIdx is unused.
+//===----------------------------------------------------------------------===//
+
+class MemInfo<Instruction inst, bits<4> baseIdx, bits<4> offsetIdx,
+              bit hasOffset, bit isPrePost, bit isLiteral> {
+  Instruction Inst       = inst;
+  bits<4>     BaseIdx    = baseIdx;
+  bits<4>     OffsetIdx  = offsetIdx;
+  bit         HasOffset  = hasOffset;
+  bit         IsPrePost  = isPrePost;
+  bit         IsLiteral  = isLiteral;
+}
+
+def MemInfoTable : GenericTable {
+  let FilterClass    = "MemInfo";
+  let CppTypeName    = "MemInfoEntry";
+  let Fields         = ["Inst", "BaseIdx", "OffsetIdx", "HasOffset",
+                        "IsPrePost", "IsLiteral"];
+  let PrimaryKey     = ["Inst"];
+  let PrimaryKeyName = "lookupMemInfoByOpcode";
+}
+
+// Semantic helper subclasses for the four addressing-mode shapes the rewriter
+// encounters. Each forwards to MemInfo with the appropriate HasOffset /
+// IsPrePost / IsLiteral flags, so the call sites only need to specify operand
+// indices.
+class MemLiteral<Instruction inst, int baseIdx>
+  : MemInfo<inst, baseIdx, 0, 0, 0, 1>;
+class MemNoOffset<Instruction inst, int baseIdx>
+  : MemInfo<inst, baseIdx, 0, 0, 0, 0>;
+class MemIndexed<Instruction inst, int baseIdx, int offsetIdx>
+  : MemInfo<inst, baseIdx, offsetIdx, 1, 0, 0>;
+class MemPrePost<Instruction inst, int baseIdx, int offsetIdx>
+  : MemInfo<inst, baseIdx, offsetIdx, 1, 1, 0>;
+
+//===----------------------------------------------------------------------===//
+// Scalar mem families with ui, roW, roX, pre, post variants. Each entry pairs
+// a base opcode name with its log2 element size (== scaled shift used by the
+// roW form). Emits both LFIVariant entries and MemInfo entries.
+//===----------------------------------------------------------------------===//
+
+class ScalarMemFam<string b, int sz> {
+  string Base = b;
+  int Log2 = sz;
+}
+
+defvar AArch64ScalarMemFamilies = [
+  ScalarMemFam<"LDRBB",  0>, ScalarMemFam<"LDRB",   0>,
+  ScalarMemFam<"LDRSBW", 0>, ScalarMemFam<"LDRSBX", 0>,
+  ScalarMemFam<"STRBB",  0>, ScalarMemFam<"STRB",   0>,
+  ScalarMemFam<"LDRHH",  1>, ScalarMemFam<"LDRH",   1>,
+  ScalarMemFam<"LDRSHW", 1>, ScalarMemFam<"LDRSHX", 1>,
+  ScalarMemFam<"STRHH",  1>, ScalarMemFam<"STRH",   1>,
+  ScalarMemFam<"LDRSW",  2>, ScalarMemFam<"LDRS",   2>,
+  ScalarMemFam<"LDRW",   2>, ScalarMemFam<"STRS",   2>,
+  ScalarMemFam<"STRW",   2>,
+  ScalarMemFam<"LDRD",   3>, ScalarMemFam<"LDRX",   3>,
+  ScalarMemFam<"STRD",   3>, ScalarMemFam<"STRX",   3>,
+  ScalarMemFam<"LDRQ",   4>, ScalarMemFam<"STRQ",   4>,
+];
+
+foreach f = AArch64ScalarMemFamilies in {
+  defvar Ui   = !cast<Instruction>(f.Base # "ui");
+  defvar RoW  = !cast<Instruction>(f.Base # "roW");
+  defvar RoX  = !cast<Instruction>(f.Base # "roX");
+  defvar Pre  = !cast<Instruction>(f.Base # "pre");
+  defvar Post = !cast<Instruction>(f.Base # "post");
+
+  def : LFIVariant<Ui,   LFI_AM_Ui.Value,   f.Log2, RoW>;
+  def : LFIVariant<RoW,  LFI_AM_RoW.Value,  f.Log2, RoW>;
+  def : LFIVariant<RoX,  LFI_AM_RoX.Value,  f.Log2, RoW>;
+  def : LFIVariant<Pre,  LFI_AM_Pre.Value,  f.Log2, RoW>;
+  def : LFIVariant<Post, LFI_AM_Post.Value, f.Log2, RoW>;
+
+  // Indexed / register-offset / register-offset-W / register-offset-X all
+  // share the same operand layout: Rt, [Rn, ...].
+  def : MemIndexed<Ui,  1, 2>;
+  def : MemIndexed<RoW, 1, 2>;
+  def : MemIndexed<RoX, 1, 2>;
+  // Pre/post-index writeback: wback, Rt, [Rn], #imm.
+  def : MemPrePost<Pre,  2, 3>;
+  def : MemPrePost<Post, 2, 3>;
+}
+
+// PRFM has ui, roW, roX but no pre/post forms. Log2 = 3 (doubleword scale).
+def : LFIVariant<PRFMui,  LFI_AM_Ui.Value,  3, PRFMroW>;
+def : LFIVariant<PRFMroW, LFI_AM_RoW.Value, 3, PRFMroW>;
+def : LFIVariant<PRFMroX, LFI_AM_RoX.Value, 3, PRFMroW>;
+
+def : MemIndexed<PRFMui,  1, 2>;
+def : MemIndexed<PRFMroW, 1, 2>;
+def : MemIndexed<PRFMroX, 1, 2>;
+
+//===----------------------------------------------------------------------===//
+// Unscaled-immediate scalar loads/stores (LDUR/STUR/PRFUM). Same operand
+// layout as the indexed forms - BaseIdx=1, OffsetIdx=2.
+//===----------------------------------------------------------------------===//
+
+foreach inst = [LDURBBi, LDURBi, LDURDi, LDURHHi, LDURHi, LDURQi,
+                LDURSBWi, LDURSBXi, LDURSHWi, LDURSHXi, LDURSWi, LDURSi,
+                LDURWi, LDURXi,
+                STURBBi, STURBi, STURDi, STURHHi, STURHi, STURQi,
+                STURSi, STURWi, STURXi,
+                PRFUMi] in
+  def : MemIndexed<inst, 1, 2>;
+
+//===----------------------------------------------------------------------===//
+// LDP/STP pair families. Pre/post variants are PairVariant entries; all
+// three variants (`i`, `pre`, `post`) get MemInfo entries.
+//===----------------------------------------------------------------------===//
+
+class PairFam<string b, int s> {
+  string Base = b;
+  int Scale = s;
+}
+
+defvar AArch64PairFamilies = [
+  PairFam<"LDPD",  8>, PairFam<"LDPQ", 16>, PairFam<"LDPSW", 4>,
+  PairFam<"LDPS",  4>, PairFam<"LDPW",  4>, PairFam<"LDPX",  8>,
+  PairFam<"STPD",  8>, PairFam<"STPQ", 16>, PairFam<"STPS",  4>,
+  PairFam<"STPW",  4>, PairFam<"STPX",  8>,
+];
+
+foreach f = AArch64PairFamilies in {
+  defvar Base = !cast<Instruction>(f.Base # "i");
+  defvar Pre  = !cast<Instruction>(f.Base # "pre");
+  defvar Post = !cast<Instruction>(f.Base # "post");
+
+  def : PairVariant<Pre,  1, f.Scale, Base>;
+  def : PairVariant<Post, 0, f.Scale, Base>;
+
+  // Indexed form: Rt, Rt2, [Rn, #imm].
+  def : MemIndexed<Base, 2, 3>;
+  // Pre/post-index: wback, Rt, Rt2, [Rn, #imm]! / [Rn], #imm.
+  def : MemPrePost<Pre,  3, 4>;
+  def : MemPrePost<Post, 3, 4>;
+}
+
+// Non-temporal pair indexed forms (LDNP/STNP). Same operand layout as `i`.
+foreach inst = [LDNPDi, LDNPQi, LDNPSi, LDNPWi, LDNPXi,
+                STNPDi, STNPQi, STNPSi, STNPWi, STNPXi] in
+  def : MemIndexed<inst, 2, 3>;
+
+//===----------------------------------------------------------------------===//
+// SIMD families. Each base instruction NAME has a post-index form NAME_POST.
+// Three subclasses, distinguished by operand layout:
+//
+//   Multi/Replicate : Vt, [Rn]                       - base BaseIdx=1
+//                     wback, Vt, [Rn], Xm            - post BaseIdx=2,Off=3
+//   Lane store      : Vt, idx, [Rn]                  - base BaseIdx=2
+//                     wback, Vt, idx, [Rn], Xm       - post BaseIdx=3,Off=4
+//   Lane load       : Vt(out), Vt(tied), idx, [Rn]   - base BaseIdx=3
+//                     wback, Vt(out), Vt(tied), idx, [Rn], Xm
+//                                                    - post BaseIdx=4,Off=5
+//===----------------------------------------------------------------------===//
+
+class SIMDPostFam<string b, int off> {
+  string Base = b;
+  int Offset = off;
+}
+
+// SIMD lane stores.
+defvar AArch64SIMDLaneStoreFams = [
+  SIMDPostFam<"ST1i8",  1>, SIMDPostFam<"ST1i16",  2>,
+  SIMDPostFam<"ST1i32", 4>, SIMDPostFam<"ST1i64",  8>,
+  SIMDPostFam<"ST2i8",  2>, SIMDPostFam<"ST2i16",  4>,
+  SIMDPostFam<"ST2i32", 8>, SIMDPostFam<"ST2i64", 16>,
+  SIMDPostFam<"ST3i8",  3>, SIMDPostFam<"ST3i16",  6>,
+  SIMDPostFam<"ST3i32",12>, SIMDPostFam<"ST3i64", 24>,
+  SIMDPostFam<"ST4i8",  4>, SIMDPostFam<"ST4i16",  8>,
+  SIMDPostFam<"ST4i32",16>, SIMDPostFam<"ST4i64", 32>,
+];
+
+// SIMD lane loads.
+defvar AArch64SIMDLaneLoadFams = [
+  SIMDPostFam<"LD1i8",  1>, SIMDPostFam<"LD1i16",  2>,
+  SIMDPostFam<"LD1i32", 4>, SIMDPostFam<"LD1i64",  8>,
+  SIMDPostFam<"LD2i8",  2>, SIMDPostFam<"LD2i16",  4>,
+  SIMDPostFam<"LD2i32", 8>, SIMDPostFam<"LD2i64", 16>,
+  SIMDPostFam<"LD3i8",  3>, SIMDPostFam<"LD3i16",  6>,
+  SIMDPostFam<"LD3i32",12>, SIMDPostFam<"LD3i64", 24>,
+  SIMDPostFam<"LD4i8",  4>, SIMDPostFam<"LD4i16",  8>,
+  SIMDPostFam<"LD4i32",16>, SIMDPostFam<"LD4i64", 32>,
+];
+
+// SIMD multi/replicate.
+defvar AArch64SIMDMultiFams = [
+  // Replicate loads.
+  SIMDPostFam<"LD1Rv8b",  1>, SIMDPostFam<"LD1Rv16b",  1>,
+  SIMDPostFam<"LD1Rv4h",  2>, SIMDPostFam<"LD1Rv8h",   2>,
+  SIMDPostFam<"LD1Rv2s",  4>, SIMDPostFam<"LD1Rv4s",   4>,
+  SIMDPostFam<"LD1Rv1d",  8>, SIMDPostFam<"LD1Rv2d",   8>,
+  SIMDPostFam<"LD2Rv8b",  2>, SIMDPostFam<"LD2Rv16b",  2>,
+  SIMDPostFam<"LD2Rv4h",  4>, SIMDPostFam<"LD2Rv8h",   4>,
+  SIMDPostFam<"LD2Rv2s",  8>, SIMDPostFam<"LD2Rv4s",   8>,
+  SIMDPostFam<"LD2Rv1d", 16>, SIMDPostFam<"LD2Rv2d",  16>,
+  SIMDPostFam<"LD3Rv8b",  3>, SIMDPostFam<"LD3Rv16b",  3>,
+  SIMDPostFam<"LD3Rv4h",  6>, SIMDPostFam<"LD3Rv8h",   6>,
+  SIMDPostFam<"LD3Rv2s", 12>, SIMDPostFam<"LD3Rv4s",  12>,
+  SIMDPostFam<"LD3Rv1d", 24>, SIMDPostFam<"LD3Rv2d",  24>,
+  SIMDPostFam<"LD4Rv8b",  4>, SIMDPostFam<"LD4Rv16b",  4>,
+  SIMDPostFam<"LD4Rv4h",  8>, SIMDPostFam<"LD4Rv8h",   8>,
+  SIMDPostFam<"LD4Rv2s", 16>, SIMDPostFam<"LD4Rv4s",  16>,
+  SIMDPostFam<"LD4Rv1d", 32>, SIMDPostFam<"LD4Rv2d",  32>,
+
+  // LD1/ST1 One register.
+  SIMDPostFam<"LD1Onev8b",  8>, SIMDPostFam<"LD1Onev16b", 16>,
+  SIMDPostFam<"LD1Onev4h",  8>, SIMDPostFam<"LD1Onev8h",  16>,
+  SIMDPostFam<"LD1Onev2s",  8>, SIMDPostFam<"LD1Onev4s",  16>,
+  SIMDPostFam<"LD1Onev1d",  8>, SIMDPostFam<"LD1Onev2d",  16>,
+  SIMDPostFam<"ST1Onev8b",  8>, SIMDPostFam<"ST1Onev16b", 16>,
+  SIMDPostFam<"ST1Onev4h",  8>, SIMDPostFam<"ST1Onev8h",  16>,
+  SIMDPostFam<"ST1Onev2s",  8>, SIMDPostFam<"ST1Onev4s",  16>,
+  SIMDPostFam<"ST1Onev1d",  8>, SIMDPostFam<"ST1Onev2d",  16>,
+
+  // LD1/ST1 Two registers.
+  SIMDPostFam<"LD1Twov8b", 16>, SIMDPostFam<"LD1Twov16b", 32>,
+  SIMDPostFam<"LD1Twov4h", 16>, SIMDPostFam<"LD1Twov8h",  32>,
+  SIMDPostFam<"LD1Twov2s", 16>, SIMDPostFam<"LD1Twov4s",  32>,
+  SIMDPostFam<"LD1Twov1d", 16>, SIMDPostFam<"LD1Twov2d",  32>,
+  SIMDPostFam<"ST1Twov8b", 16>, SIMDPostFam<"ST1Twov16b", 32>,
+  SIMDPostFam<"ST1Twov4h", 16>, SIMDPostFam<"ST1Twov8h",  32>,
+  SIMDPostFam<"ST1Twov2s", 16>, SIMDPostFam<"ST1Twov4s",  32>,
+  SIMDPostFam<"ST1Twov1d", 16>, SIMDPostFam<"ST1Twov2d",  32>,
+
+  // LD1/ST1 Three registers.
+  SIMDPostFam<"LD1Threev8b", 24>, SIMDPostFam<"LD1Threev16b", 48>,
+  SIMDPostFam<"LD1Threev4h", 24>, SIMDPostFam<"LD1Threev8h",  48>,
+  SIMDPostFam<"LD1Threev2s", 24>, SIMDPostFam<"LD1Threev4s",  48>,
+  SIMDPostFam<"LD1Threev1d", 24>, SIMDPostFam<"LD1Threev2d",  48>,
+  SIMDPostFam<"ST1Threev8b", 24>, SIMDPostFam<"ST1Threev16b", 48>,
+  SIMDPostFam<"ST1Threev4h", 24>, SIMDPostFam<"ST1Threev8h",  48>,
+  SIMDPostFam<"ST1Threev2s", 24>, SIMDPostFam<"ST1Threev4s",  48>,
+  SIMDPostFam<"ST1Threev1d", 24>, SIMDPostFam<"ST1Threev2d",  48>,
+
+  // LD1/ST1 Four registers.
+  SIMDPostFam<"LD1Fourv8b", 32>, SIMDPostFam<"LD1Fourv16b", 64>,
+  SIMDPostFam<"LD1Fourv4h", 32>, SIMDPostFam<"LD1Fourv8h",  64>,
+  SIMDPostFam<"LD1Fourv2s", 32>, SIMDPostFam<"LD1Fourv4s",  64>,
+  SIMDPostFam<"LD1Fourv1d", 32>, SIMDPostFam<"LD1Fourv2d",  64>,
+  SIMDPostFam<"ST1Fourv8b", 32>, SIMDPostFam<"ST1Fourv16b", 64>,
+  SIMDPostFam<"ST1Fourv4h", 32>, SIMDPostFam<"ST1Fourv8h",  64>,
+  SIMDPostFam<"ST1Fourv2s", 32>, SIMDPostFam<"ST1Fourv4s",  64>,
+  SIMDPostFam<"ST1Fourv1d", 32>, SIMDPostFam<"ST1Fourv2d",  64>,
+
+  // LD2/ST2 Two registers.
+  SIMDPostFam<"LD2Twov8b",  16>, SIMDPostFam<"LD2Twov16b", 32>,
+  SIMDPostFam<"LD2Twov4h",  16>, SIMDPostFam<"LD2Twov8h",  32>,
+  SIMDPostFam<"LD2Twov2s",  16>, SIMDPostFam<"LD2Twov4s",  32>,
+  SIMDPostFam<"LD2Twov2d",  32>,
+  SIMDPostFam<"ST2Twov8b",  16>, SIMDPostFam<"ST2Twov16b", 32>,
+  SIMDPostFam<"ST2Twov4h",  16>, SIMDPostFam<"ST2Twov8h",  32>,
+  SIMDPostFam<"ST2Twov2s",  16>, SIMDPostFam<"ST2Twov4s",  32>,
+  SIMDPostFam<"ST2Twov2d",  32>,
+
+  // LD3/ST3 Three registers.
+  SIMDPostFam<"LD3Threev8b",  24>, SIMDPostFam<"LD3Threev16b", 48>,
+  SIMDPostFam<"LD3Threev4h",  24>, SIMDPostFam<"LD3Threev8h",  48>,
+  SIMDPostFam<"LD3Threev2s",  24>, SIMDPostFam<"LD3Threev4s",  48>,
+  SIMDPostFam<"LD3Threev2d",  48>,
+  SIMDPostFam<"ST3Threev8b",  24>, SIMDPostFam<"ST3Threev16b", 48>,
+  SIMDPostFam<"ST3Threev4h",  24>, SIMDPostFam<"ST3Threev8h",  48>,
+  SIMDPostFam<"ST3Threev2s",  24>, SIMDPostFam<"ST3Threev4s",  48>,
+  SIMDPostFam<"ST3Threev2d",  48>,
+
+  // LD4/ST4 Four registers.
+  SIMDPostFam<"LD4Fourv8b",  32>, SIMDPostFam<"LD4Fourv16b", 64>,
+  SIMDPostFam<"LD4Fourv4h",  32>, SIMDPostFam<"LD4Fourv8h",  64>,
+  SIMDPostFam<"LD4Fourv2s",  32>, SIMDPostFam<"LD4Fourv4s",  64>,
+  SIMDPostFam<"LD4Fourv2d",  64>,
+  SIMDPostFam<"ST4Fourv8b",  32>, SIMDPostFam<"ST4Fourv16b", 64>,
+  SIMDPostFam<"ST4Fourv4h",  32>, SIMDPostFam<"ST4Fourv8h",  64>,
+  SIMDPostFam<"ST4Fourv2s",  32>, SIMDPostFam<"ST4Fourv4s",  64>,
+  SIMDPostFam<"ST4Fourv2d",  64>,
+];
+
+foreach f = AArch64SIMDMultiFams in {
+  defvar Base = !cast<Instruction>(f.Base);
+  defvar Post = !cast<Instruction>(f.Base # "_POST");
+  def : SIMDPost<Post, f.Offset, Base>;
+  def : MemNoOffset<Base, 1>;
+  def : MemPrePost<Post, 2, 3>;
+}
+
+foreach f = AArch64SIMDLaneStoreFams in {
+  defvar Base = !cast<Instruction>(f.Base);
+  defvar Post = !cast<Instruction>(f.Base # "_POST");
+  def : SIMDPost<Post, f.Offset, Base>;
+  def : MemNoOffset<Base, 2>;
+  def : MemPrePost<Post, 3, 4>;
+}
+
+foreach f = AArch64SIMDLaneLoadFams in {
+  defvar Base = !cast<Instruction>(f.Base);
+  defvar Post = !cast<Instruction>(f.Base # "_POST");
+  def : SIMDPost<Post, f.Offset, Base>;
+  def : MemNoOffset<Base, 3>;
+  def : MemPrePost<Post, 4, 5>;
+}
+
+//===----------------------------------------------------------------------===//
+// PC-relative literal loads: Rt, label. BaseIdx=0, no offset operand.
+//===----------------------------------------------------------------------===//
+
+foreach inst = [LDRWl, LDRXl, LDRSWl, LDRSl, LDRDl, LDRQl, PRFMl] in
+  def : MemLiteral<inst, 0>;
+
+//===----------------------------------------------------------------------===//
+// Exclusive / acquire / RCPC loads and store-release: Rt, [Rn].
+//===----------------------------------------------------------------------===//
+
+foreach inst = [LDXRB, LDXRH, LDXRW, LDXRX,
+                LDAXRB, LDAXRH, LDAXRW, LDAXRX,
+                LDARB, LDARH, LDARW, LDARX,
+                LDLARB, LDLARH, LDLARW, LDLARX,
+                // RCPC
+                LDAPRB, LDAPRH, LDAPRW, LDAPRX,
+                // Store-release
+                STLRB, STLRH, STLRW, STLRX,
+                STLLRB, STLLRH, STLLRW, STLLRX] in
+  def : MemNoOffset<inst, 1>;
+
+//===----------------------------------------------------------------------===//
+// Exclusive stores: Ws, Rt, [Rn]. Exclusive pair loads: Rt, Rt2, [Rn].
+//===----------------------------------------------------------------------===//
+
+foreach inst = [STXRB, STXRH, STXRW, STXRX,
+                STLXRB, STLXRH, STLXRW, STLXRX,
+                LDXPW, LDXPX, LDAXPW, LDAXPX] in
+  def : MemNoOffset<inst, 2>;
+
+// Exclusive store pairs: Ws, Rt, Rt2, [Rn].
+foreach inst = [STXPW, STXPX, STLXPW, STLXPX] in
+  def : MemNoOffset<inst, 3>;
+
+//===----------------------------------------------------------------------===//
+// CAS variants: Rs(out), Rs(in, tied), Rt, [Rn]. BaseIdx=3.
+//===----------------------------------------------------------------------===//
+
+defvar AArch64CASBases = ["CAS", "CASA", "CASL", "CASAL"];
+defvar AArch64CASSuffixes = ["B", "H", "W", "X"];
+
+foreach base = AArch64CASBases in
+  foreach suff = AArch64CASSuffixes in
+    def : MemNoOffset<!cast<Instruction>(base # suff), 3>;
+
+// CASP variants: Ws_Ws2(out), Ws_Ws2(in, tied), Wt_Wt2, [Rn]. BaseIdx=3.
+foreach inst = [CASPW, CASPX, CASPAW, CASPAX,
+                CASPLW, CASPLX, CASPALW, CASPALX] in
+  def : MemNoOffset<inst, 3>;
+
+//===----------------------------------------------------------------------===//
+// LSE atomics: Rs, Rt, [Rn].
+//===----------------------------------------------------------------------===//
+
+defvar AArch64LSEBases = [
+  "LDADD", "LDCLR", "LDEOR", "LDSET",
+  "LDSMAX", "LDSMIN", "LDUMAX", "LDUMIN", "SWP",
+];
+defvar AArch64LSESuffixes = [
+  "B",   "H",   "W",   "X",
+  "AB",  "AH",  "AW",  "AX",
+  "LB",  "LH",  "LW",  "LX",
+  "ALB", "ALH", "ALW", "ALX",
+];
+
+foreach base = AArch64LSEBases in
+  foreach suff = AArch64LSESuffixes in
+    def : MemNoOffset<!cast<Instruction>(base # suff), 2>;

--- a/llvm/lib/Target/AArch64/AArch64LFI.td
+++ b/llvm/lib/Target/AArch64/AArch64LFI.td
@@ -6,21 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Per-opcode metadata consumed by AArch64MCLFIRewriter. The rewriter queries
-// four generated lookup tables:
-//
-// * lookupLFIVariantByOpcode: scalar load/store addressing-mode info
-//   (ui/roW/roX/pre/post + log2 element size + cross-reference to the RoW
-//   variant).
-//
-// * lookupPairVariantByOpcode: LDP/STP pre/post-index info (base opcode +
-//   scale + pre vs. post).
-//
-// * lookupSIMDPostByOpcode: SIMD post-index info (base opcode + natural byte
-//   offset).
-//
-// * lookupMemInfoByOpcode: generic operand-layout info used by the base
-//   load/store rewriter (base/offset operand indices, IsPrePost, IsLiteral).
+// Per-opcode metadata consumed by AArch64MCLFIRewriter.
 //
 //===----------------------------------------------------------------------===//
 
@@ -34,96 +20,61 @@ def LFI_AM_Pre  : LFIAddrMode<3>;
 def LFI_AM_Post : LFIAddrMode<4>;
 
 //===----------------------------------------------------------------------===//
-// LFIVariant - scalar load/store variants
-//
-// One record per (family, addressing mode) combination. RoWInst is the
-// matching RoW variant of the same family.
+// Searchable Tables
 //===----------------------------------------------------------------------===//
 
-class LFIVariant<Instruction inst, bits<3> addrMode, bits<3> log2Size,
-                 Instruction roWInst> {
-  Instruction Inst     = inst;
-  bits<3>     AddrMode = addrMode;
-  bits<3>     Log2Size = log2Size;
-  Instruction RoWInst  = roWInst;
-}
-
 def LFIVariantTable : GenericTable {
-  let FilterClass    = "LFIVariant";
+  let FilterClass    = "LFIInstruction";
+  let FilterClassField = "HasLFIVariant";
   let CppTypeName    = "LFIVariantEntry";
-  let Fields         = ["Inst", "AddrMode", "Log2Size", "RoWInst"];
-  let PrimaryKey     = ["Inst"];
+  let Fields         = ["LFIInst", "AddrMode", "Log2Size", "RoWInst"];
+  let PrimaryKey     = ["LFIInst"];
   let PrimaryKeyName = "lookupLFIVariantByOpcode";
 }
 
-//===----------------------------------------------------------------------===//
-// PairVariant - LDP/STP pre/post-index entries
-//===----------------------------------------------------------------------===//
-
-class PairVariant<Instruction inst, bit isPre, bits<5> scale,
-                  Instruction baseInst> {
-  Instruction Inst     = inst;
-  bit         IsPre    = isPre;
-  bits<5>     Scale    = scale;
-  Instruction BaseInst = baseInst;
-}
-
 def PairVariantTable : GenericTable {
-  let FilterClass    = "PairVariant";
+  let FilterClass    = "LFIInstruction";
+  let FilterClassField = "HasPairVariant";
   let CppTypeName    = "PairVariantEntry";
-  let Fields         = ["Inst", "IsPre", "Scale", "BaseInst"];
-  let PrimaryKey     = ["Inst"];
+  let Fields         = ["LFIInst", "IsPre", "Scale", "BaseInst"];
+  let PrimaryKey     = ["LFIInst"];
   let PrimaryKeyName = "lookupPairVariantByOpcode";
 }
 
-//===----------------------------------------------------------------------===//
-// SIMDPost - SIMD post-index entries (multi/lane-load/lane-store).
-//===----------------------------------------------------------------------===//
-
-class SIMDPost<Instruction inst, bits<7> naturalOffset,
-               Instruction baseInst> {
-  Instruction Inst          = inst;
-  bits<7>     NaturalOffset = naturalOffset;
-  Instruction BaseInst      = baseInst;
-}
-
 def SIMDPostTable : GenericTable {
-  let FilterClass    = "SIMDPost";
+  let FilterClass    = "LFIInstruction";
+  let FilterClassField = "HasSIMDPost";
   let CppTypeName    = "SIMDPostEntry";
-  let Fields         = ["Inst", "NaturalOffset", "BaseInst"];
-  let PrimaryKey     = ["Inst"];
+  let Fields         = ["LFIInst", "NaturalOffset", "BaseInst"];
+  let PrimaryKey     = ["LFIInst"];
   let PrimaryKeyName = "lookupSIMDPostByOpcode";
 }
 
-//===----------------------------------------------------------------------===//
-// MemInfo - per-opcode operand layout for the base load/store rewriter.
-//
-// HasOffset = 0 means OffsetIdx is unused.
-//===----------------------------------------------------------------------===//
-
-class MemInfo<Instruction inst, bits<4> baseIdx, bits<4> offsetIdx,
-              bit hasOffset, bit isPrePost, bit isLiteral> {
-  Instruction Inst       = inst;
-  bits<4>     BaseIdx    = baseIdx;
-  bits<4>     OffsetIdx  = offsetIdx;
-  bit         HasOffset  = hasOffset;
-  bit         IsPrePost  = isPrePost;
-  bit         IsLiteral  = isLiteral;
-}
-
 def MemInfoTable : GenericTable {
-  let FilterClass    = "MemInfo";
+  let FilterClass    = "LFIInstruction";
+  let FilterClassField = "IsLFIMem";
   let CppTypeName    = "MemInfoEntry";
-  let Fields         = ["Inst", "BaseIdx", "OffsetIdx", "HasOffset",
+  let Fields         = ["LFIInst", "BaseIdx", "OffsetIdx", "HasOffset",
                         "IsPrePost", "IsLiteral"];
-  let PrimaryKey     = ["Inst"];
+  let PrimaryKey     = ["LFIInst"];
   let PrimaryKeyName = "lookupMemInfoByOpcode";
 }
 
-// Semantic helper subclasses for the four addressing-mode shapes the rewriter
-// encounters. Each forwards to MemInfo with the appropriate HasOffset /
-// IsPrePost / IsLiteral flags, so the call sites only need to specify operand
-// indices.
+//===----------------------------------------------------------------------===//
+// MemInfo helper subclasses (used to explicitly map CAS/LSE/exclusive ops)
+//===----------------------------------------------------------------------===//
+
+class MemInfo<Instruction inst, bits<4> baseIdx, bits<4> offsetIdx,
+              bit hasOffset, bit isPrePost, bit isLiteral> : LFIInstruction {
+  let LFIInst   = inst;
+  let IsLFIMem  = 1;
+  let BaseIdx   = baseIdx;
+  let OffsetIdx = offsetIdx;
+  let HasOffset = hasOffset;
+  let IsPrePost = isPrePost;
+  let IsLiteral = isLiteral;
+}
+
 class MemLiteral<Instruction inst, int baseIdx>
   : MemInfo<inst, baseIdx, 0, 0, 0, 1>;
 class MemNoOffset<Instruction inst, int baseIdx>
@@ -132,64 +83,6 @@ class MemIndexed<Instruction inst, int baseIdx, int offsetIdx>
   : MemInfo<inst, baseIdx, offsetIdx, 1, 0, 0>;
 class MemPrePost<Instruction inst, int baseIdx, int offsetIdx>
   : MemInfo<inst, baseIdx, offsetIdx, 1, 1, 0>;
-
-//===----------------------------------------------------------------------===//
-// Scalar mem families with ui, roW, roX, pre, post variants. Each entry pairs
-// a base opcode name with its log2 element size (== scaled shift used by the
-// roW form). Emits both LFIVariant entries and MemInfo entries.
-//===----------------------------------------------------------------------===//
-
-class ScalarMemFam<string b, int sz> {
-  string Base = b;
-  int Log2 = sz;
-}
-
-defvar AArch64ScalarMemFamilies = [
-  ScalarMemFam<"LDRBB",  0>, ScalarMemFam<"LDRB",   0>,
-  ScalarMemFam<"LDRSBW", 0>, ScalarMemFam<"LDRSBX", 0>,
-  ScalarMemFam<"STRBB",  0>, ScalarMemFam<"STRB",   0>,
-  ScalarMemFam<"LDRHH",  1>, ScalarMemFam<"LDRH",   1>,
-  ScalarMemFam<"LDRSHW", 1>, ScalarMemFam<"LDRSHX", 1>,
-  ScalarMemFam<"STRHH",  1>, ScalarMemFam<"STRH",   1>,
-  ScalarMemFam<"LDRSW",  2>, ScalarMemFam<"LDRS",   2>,
-  ScalarMemFam<"LDRW",   2>, ScalarMemFam<"STRS",   2>,
-  ScalarMemFam<"STRW",   2>,
-  ScalarMemFam<"LDRD",   3>, ScalarMemFam<"LDRX",   3>,
-  ScalarMemFam<"STRD",   3>, ScalarMemFam<"STRX",   3>,
-  ScalarMemFam<"LDRQ",   4>, ScalarMemFam<"STRQ",   4>,
-];
-
-foreach f = AArch64ScalarMemFamilies in {
-  defvar Ui   = !cast<Instruction>(f.Base # "ui");
-  defvar RoW  = !cast<Instruction>(f.Base # "roW");
-  defvar RoX  = !cast<Instruction>(f.Base # "roX");
-  defvar Pre  = !cast<Instruction>(f.Base # "pre");
-  defvar Post = !cast<Instruction>(f.Base # "post");
-
-  def : LFIVariant<Ui,   LFI_AM_Ui.Value,   f.Log2, RoW>;
-  def : LFIVariant<RoW,  LFI_AM_RoW.Value,  f.Log2, RoW>;
-  def : LFIVariant<RoX,  LFI_AM_RoX.Value,  f.Log2, RoW>;
-  def : LFIVariant<Pre,  LFI_AM_Pre.Value,  f.Log2, RoW>;
-  def : LFIVariant<Post, LFI_AM_Post.Value, f.Log2, RoW>;
-
-  // Indexed / register-offset / register-offset-W / register-offset-X all
-  // share the same operand layout: Rt, [Rn, ...].
-  def : MemIndexed<Ui,  1, 2>;
-  def : MemIndexed<RoW, 1, 2>;
-  def : MemIndexed<RoX, 1, 2>;
-  // Pre/post-index writeback: wback, Rt, [Rn], #imm.
-  def : MemPrePost<Pre,  2, 3>;
-  def : MemPrePost<Post, 2, 3>;
-}
-
-// PRFM has ui, roW, roX but no pre/post forms. Log2 = 3 (doubleword scale).
-def : LFIVariant<PRFMui,  LFI_AM_Ui.Value,  3, PRFMroW>;
-def : LFIVariant<PRFMroW, LFI_AM_RoW.Value, 3, PRFMroW>;
-def : LFIVariant<PRFMroX, LFI_AM_RoX.Value, 3, PRFMroW>;
-
-def : MemIndexed<PRFMui,  1, 2>;
-def : MemIndexed<PRFMroW, 1, 2>;
-def : MemIndexed<PRFMroX, 1, 2>;
 
 //===----------------------------------------------------------------------===//
 // Unscaled-immediate scalar loads/stores (LDUR/STUR/PRFUM). Same operand
@@ -205,198 +98,12 @@ foreach inst = [LDURBBi, LDURBi, LDURDi, LDURHHi, LDURHi, LDURQi,
   def : MemIndexed<inst, 1, 2>;
 
 //===----------------------------------------------------------------------===//
-// LDP/STP pair families. Pre/post variants are PairVariant entries; all
-// three variants (`i`, `pre`, `post`) get MemInfo entries.
+// Non-temporal pair indexed forms (LDNP/STNP). Same operand layout as `i`.
 //===----------------------------------------------------------------------===//
 
-class PairFam<string b, int s> {
-  string Base = b;
-  int Scale = s;
-}
-
-defvar AArch64PairFamilies = [
-  PairFam<"LDPD",  8>, PairFam<"LDPQ", 16>, PairFam<"LDPSW", 4>,
-  PairFam<"LDPS",  4>, PairFam<"LDPW",  4>, PairFam<"LDPX",  8>,
-  PairFam<"STPD",  8>, PairFam<"STPQ", 16>, PairFam<"STPS",  4>,
-  PairFam<"STPW",  4>, PairFam<"STPX",  8>,
-];
-
-foreach f = AArch64PairFamilies in {
-  defvar Base = !cast<Instruction>(f.Base # "i");
-  defvar Pre  = !cast<Instruction>(f.Base # "pre");
-  defvar Post = !cast<Instruction>(f.Base # "post");
-
-  def : PairVariant<Pre,  1, f.Scale, Base>;
-  def : PairVariant<Post, 0, f.Scale, Base>;
-
-  // Indexed form: Rt, Rt2, [Rn, #imm].
-  def : MemIndexed<Base, 2, 3>;
-  // Pre/post-index: wback, Rt, Rt2, [Rn, #imm]! / [Rn], #imm.
-  def : MemPrePost<Pre,  3, 4>;
-  def : MemPrePost<Post, 3, 4>;
-}
-
-// Non-temporal pair indexed forms (LDNP/STNP). Same operand layout as `i`.
 foreach inst = [LDNPDi, LDNPQi, LDNPSi, LDNPWi, LDNPXi,
                 STNPDi, STNPQi, STNPSi, STNPWi, STNPXi] in
   def : MemIndexed<inst, 2, 3>;
-
-//===----------------------------------------------------------------------===//
-// SIMD families. Each base instruction NAME has a post-index form NAME_POST.
-// Three subclasses, distinguished by operand layout:
-//
-//   Multi/Replicate : Vt, [Rn]                       - base BaseIdx=1
-//                     wback, Vt, [Rn], Xm            - post BaseIdx=2,Off=3
-//   Lane store      : Vt, idx, [Rn]                  - base BaseIdx=2
-//                     wback, Vt, idx, [Rn], Xm       - post BaseIdx=3,Off=4
-//   Lane load       : Vt(out), Vt(tied), idx, [Rn]   - base BaseIdx=3
-//                     wback, Vt(out), Vt(tied), idx, [Rn], Xm
-//                                                    - post BaseIdx=4,Off=5
-//===----------------------------------------------------------------------===//
-
-class SIMDPostFam<string b, int off> {
-  string Base = b;
-  int Offset = off;
-}
-
-// SIMD lane stores.
-defvar AArch64SIMDLaneStoreFams = [
-  SIMDPostFam<"ST1i8",  1>, SIMDPostFam<"ST1i16",  2>,
-  SIMDPostFam<"ST1i32", 4>, SIMDPostFam<"ST1i64",  8>,
-  SIMDPostFam<"ST2i8",  2>, SIMDPostFam<"ST2i16",  4>,
-  SIMDPostFam<"ST2i32", 8>, SIMDPostFam<"ST2i64", 16>,
-  SIMDPostFam<"ST3i8",  3>, SIMDPostFam<"ST3i16",  6>,
-  SIMDPostFam<"ST3i32",12>, SIMDPostFam<"ST3i64", 24>,
-  SIMDPostFam<"ST4i8",  4>, SIMDPostFam<"ST4i16",  8>,
-  SIMDPostFam<"ST4i32",16>, SIMDPostFam<"ST4i64", 32>,
-];
-
-// SIMD lane loads.
-defvar AArch64SIMDLaneLoadFams = [
-  SIMDPostFam<"LD1i8",  1>, SIMDPostFam<"LD1i16",  2>,
-  SIMDPostFam<"LD1i32", 4>, SIMDPostFam<"LD1i64",  8>,
-  SIMDPostFam<"LD2i8",  2>, SIMDPostFam<"LD2i16",  4>,
-  SIMDPostFam<"LD2i32", 8>, SIMDPostFam<"LD2i64", 16>,
-  SIMDPostFam<"LD3i8",  3>, SIMDPostFam<"LD3i16",  6>,
-  SIMDPostFam<"LD3i32",12>, SIMDPostFam<"LD3i64", 24>,
-  SIMDPostFam<"LD4i8",  4>, SIMDPostFam<"LD4i16",  8>,
-  SIMDPostFam<"LD4i32",16>, SIMDPostFam<"LD4i64", 32>,
-];
-
-// SIMD multi/replicate.
-defvar AArch64SIMDMultiFams = [
-  // Replicate loads.
-  SIMDPostFam<"LD1Rv8b",  1>, SIMDPostFam<"LD1Rv16b",  1>,
-  SIMDPostFam<"LD1Rv4h",  2>, SIMDPostFam<"LD1Rv8h",   2>,
-  SIMDPostFam<"LD1Rv2s",  4>, SIMDPostFam<"LD1Rv4s",   4>,
-  SIMDPostFam<"LD1Rv1d",  8>, SIMDPostFam<"LD1Rv2d",   8>,
-  SIMDPostFam<"LD2Rv8b",  2>, SIMDPostFam<"LD2Rv16b",  2>,
-  SIMDPostFam<"LD2Rv4h",  4>, SIMDPostFam<"LD2Rv8h",   4>,
-  SIMDPostFam<"LD2Rv2s",  8>, SIMDPostFam<"LD2Rv4s",   8>,
-  SIMDPostFam<"LD2Rv1d", 16>, SIMDPostFam<"LD2Rv2d",  16>,
-  SIMDPostFam<"LD3Rv8b",  3>, SIMDPostFam<"LD3Rv16b",  3>,
-  SIMDPostFam<"LD3Rv4h",  6>, SIMDPostFam<"LD3Rv8h",   6>,
-  SIMDPostFam<"LD3Rv2s", 12>, SIMDPostFam<"LD3Rv4s",  12>,
-  SIMDPostFam<"LD3Rv1d", 24>, SIMDPostFam<"LD3Rv2d",  24>,
-  SIMDPostFam<"LD4Rv8b",  4>, SIMDPostFam<"LD4Rv16b",  4>,
-  SIMDPostFam<"LD4Rv4h",  8>, SIMDPostFam<"LD4Rv8h",   8>,
-  SIMDPostFam<"LD4Rv2s", 16>, SIMDPostFam<"LD4Rv4s",  16>,
-  SIMDPostFam<"LD4Rv1d", 32>, SIMDPostFam<"LD4Rv2d",  32>,
-
-  // LD1/ST1 One register.
-  SIMDPostFam<"LD1Onev8b",  8>, SIMDPostFam<"LD1Onev16b", 16>,
-  SIMDPostFam<"LD1Onev4h",  8>, SIMDPostFam<"LD1Onev8h",  16>,
-  SIMDPostFam<"LD1Onev2s",  8>, SIMDPostFam<"LD1Onev4s",  16>,
-  SIMDPostFam<"LD1Onev1d",  8>, SIMDPostFam<"LD1Onev2d",  16>,
-  SIMDPostFam<"ST1Onev8b",  8>, SIMDPostFam<"ST1Onev16b", 16>,
-  SIMDPostFam<"ST1Onev4h",  8>, SIMDPostFam<"ST1Onev8h",  16>,
-  SIMDPostFam<"ST1Onev2s",  8>, SIMDPostFam<"ST1Onev4s",  16>,
-  SIMDPostFam<"ST1Onev1d",  8>, SIMDPostFam<"ST1Onev2d",  16>,
-
-  // LD1/ST1 Two registers.
-  SIMDPostFam<"LD1Twov8b", 16>, SIMDPostFam<"LD1Twov16b", 32>,
-  SIMDPostFam<"LD1Twov4h", 16>, SIMDPostFam<"LD1Twov8h",  32>,
-  SIMDPostFam<"LD1Twov2s", 16>, SIMDPostFam<"LD1Twov4s",  32>,
-  SIMDPostFam<"LD1Twov1d", 16>, SIMDPostFam<"LD1Twov2d",  32>,
-  SIMDPostFam<"ST1Twov8b", 16>, SIMDPostFam<"ST1Twov16b", 32>,
-  SIMDPostFam<"ST1Twov4h", 16>, SIMDPostFam<"ST1Twov8h",  32>,
-  SIMDPostFam<"ST1Twov2s", 16>, SIMDPostFam<"ST1Twov4s",  32>,
-  SIMDPostFam<"ST1Twov1d", 16>, SIMDPostFam<"ST1Twov2d",  32>,
-
-  // LD1/ST1 Three registers.
-  SIMDPostFam<"LD1Threev8b", 24>, SIMDPostFam<"LD1Threev16b", 48>,
-  SIMDPostFam<"LD1Threev4h", 24>, SIMDPostFam<"LD1Threev8h",  48>,
-  SIMDPostFam<"LD1Threev2s", 24>, SIMDPostFam<"LD1Threev4s",  48>,
-  SIMDPostFam<"LD1Threev1d", 24>, SIMDPostFam<"LD1Threev2d",  48>,
-  SIMDPostFam<"ST1Threev8b", 24>, SIMDPostFam<"ST1Threev16b", 48>,
-  SIMDPostFam<"ST1Threev4h", 24>, SIMDPostFam<"ST1Threev8h",  48>,
-  SIMDPostFam<"ST1Threev2s", 24>, SIMDPostFam<"ST1Threev4s",  48>,
-  SIMDPostFam<"ST1Threev1d", 24>, SIMDPostFam<"ST1Threev2d",  48>,
-
-  // LD1/ST1 Four registers.
-  SIMDPostFam<"LD1Fourv8b", 32>, SIMDPostFam<"LD1Fourv16b", 64>,
-  SIMDPostFam<"LD1Fourv4h", 32>, SIMDPostFam<"LD1Fourv8h",  64>,
-  SIMDPostFam<"LD1Fourv2s", 32>, SIMDPostFam<"LD1Fourv4s",  64>,
-  SIMDPostFam<"LD1Fourv1d", 32>, SIMDPostFam<"LD1Fourv2d",  64>,
-  SIMDPostFam<"ST1Fourv8b", 32>, SIMDPostFam<"ST1Fourv16b", 64>,
-  SIMDPostFam<"ST1Fourv4h", 32>, SIMDPostFam<"ST1Fourv8h",  64>,
-  SIMDPostFam<"ST1Fourv2s", 32>, SIMDPostFam<"ST1Fourv4s",  64>,
-  SIMDPostFam<"ST1Fourv1d", 32>, SIMDPostFam<"ST1Fourv2d",  64>,
-
-  // LD2/ST2 Two registers.
-  SIMDPostFam<"LD2Twov8b",  16>, SIMDPostFam<"LD2Twov16b", 32>,
-  SIMDPostFam<"LD2Twov4h",  16>, SIMDPostFam<"LD2Twov8h",  32>,
-  SIMDPostFam<"LD2Twov2s",  16>, SIMDPostFam<"LD2Twov4s",  32>,
-  SIMDPostFam<"LD2Twov2d",  32>,
-  SIMDPostFam<"ST2Twov8b",  16>, SIMDPostFam<"ST2Twov16b", 32>,
-  SIMDPostFam<"ST2Twov4h",  16>, SIMDPostFam<"ST2Twov8h",  32>,
-  SIMDPostFam<"ST2Twov2s",  16>, SIMDPostFam<"ST2Twov4s",  32>,
-  SIMDPostFam<"ST2Twov2d",  32>,
-
-  // LD3/ST3 Three registers.
-  SIMDPostFam<"LD3Threev8b",  24>, SIMDPostFam<"LD3Threev16b", 48>,
-  SIMDPostFam<"LD3Threev4h",  24>, SIMDPostFam<"LD3Threev8h",  48>,
-  SIMDPostFam<"LD3Threev2s",  24>, SIMDPostFam<"LD3Threev4s",  48>,
-  SIMDPostFam<"LD3Threev2d",  48>,
-  SIMDPostFam<"ST3Threev8b",  24>, SIMDPostFam<"ST3Threev16b", 48>,
-  SIMDPostFam<"ST3Threev4h",  24>, SIMDPostFam<"ST3Threev8h",  48>,
-  SIMDPostFam<"ST3Threev2s",  24>, SIMDPostFam<"ST3Threev4s",  48>,
-  SIMDPostFam<"ST3Threev2d",  48>,
-
-  // LD4/ST4 Four registers.
-  SIMDPostFam<"LD4Fourv8b",  32>, SIMDPostFam<"LD4Fourv16b", 64>,
-  SIMDPostFam<"LD4Fourv4h",  32>, SIMDPostFam<"LD4Fourv8h",  64>,
-  SIMDPostFam<"LD4Fourv2s",  32>, SIMDPostFam<"LD4Fourv4s",  64>,
-  SIMDPostFam<"LD4Fourv2d",  64>,
-  SIMDPostFam<"ST4Fourv8b",  32>, SIMDPostFam<"ST4Fourv16b", 64>,
-  SIMDPostFam<"ST4Fourv4h",  32>, SIMDPostFam<"ST4Fourv8h",  64>,
-  SIMDPostFam<"ST4Fourv2s",  32>, SIMDPostFam<"ST4Fourv4s",  64>,
-  SIMDPostFam<"ST4Fourv2d",  64>,
-];
-
-foreach f = AArch64SIMDMultiFams in {
-  defvar Base = !cast<Instruction>(f.Base);
-  defvar Post = !cast<Instruction>(f.Base # "_POST");
-  def : SIMDPost<Post, f.Offset, Base>;
-  def : MemNoOffset<Base, 1>;
-  def : MemPrePost<Post, 2, 3>;
-}
-
-foreach f = AArch64SIMDLaneStoreFams in {
-  defvar Base = !cast<Instruction>(f.Base);
-  defvar Post = !cast<Instruction>(f.Base # "_POST");
-  def : SIMDPost<Post, f.Offset, Base>;
-  def : MemNoOffset<Base, 2>;
-  def : MemPrePost<Post, 3, 4>;
-}
-
-foreach f = AArch64SIMDLaneLoadFams in {
-  defvar Base = !cast<Instruction>(f.Base);
-  defvar Post = !cast<Instruction>(f.Base # "_POST");
-  def : SIMDPost<Post, f.Offset, Base>;
-  def : MemNoOffset<Base, 3>;
-  def : MemPrePost<Post, 4, 5>;
-}
 
 //===----------------------------------------------------------------------===//
 // PC-relative literal loads: Rt, label. BaseIdx=0, no offset operand.

--- a/llvm/lib/Target/AArch64/AArch64LFIInstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64LFIInstrFormats.td
@@ -1,0 +1,119 @@
+def LFIDummyInst : Instruction {
+  let OutOperandList = (outs);
+  let InOperandList = (ins);
+  let isPseudo = 1;
+  let isCodeGenOnly = 1;
+  let hasNoSchedulingInfo = 1;
+}
+
+class LFIInstruction {
+  Instruction LFIInst = !cast<Instruction>(NAME);
+
+  // Generic memory operand layout (MemInfo Table)
+  bit         IsLFIMem      = 0;
+  bits<4>     BaseIdx       = 0;
+  bits<4>     OffsetIdx     = 0;
+  bit         HasOffset     = 0;
+  bit         IsPrePost     = 0;
+  bit         IsLiteral     = 0;
+
+  // Scalar variants (LFIVariant Table)
+  bit         HasLFIVariant = 0;
+  bits<3>     AddrMode      = 0;
+  bits<3>     Log2Size      = !cond(
+    !ne(NAME, !subst("LDRQ", "", !subst("STRQ", "", NAME))) : 4,
+    !ne(NAME, !subst("LDRX", "", !subst("STRX", "", NAME))) : 3,
+    !ne(NAME, !subst("LDRD", "", !subst("STRD", "", NAME))) : 3,
+    !ne(NAME, !subst("LDRSB", "", NAME)) : 0,
+    !ne(NAME, !subst("LDRSH", "", NAME)) : 1,
+    !ne(NAME, !subst("LDRW", "", !subst("STRW", "", NAME))) : 2,
+    !ne(NAME, !subst("LDRS", "", !subst("STRS", "", NAME))) : 2,
+    !ne(NAME, !subst("LDRH", "", !subst("STRH", "", NAME))) : 1,
+    1 : 0
+  );
+  Instruction RoWInst       = LFIDummyInst;
+
+  // Pair variants (PairVariant Table)
+  bit         HasPairVariant = 0;
+  bit         IsPre          = 0;
+  bits<5>     Scale          = 0;
+  Instruction BaseInst       = LFIDummyInst;
+
+  // SIMD Post-index (SIMDPost Table)
+  bit         HasSIMDPost    = 0;
+  bits<7>     NaturalOffset  = 0;
+}
+
+// Centralized, non-brittle Scalar Variant format helper (Option A)
+class LFIScalarVariant : LFIInstruction {
+  let HasLFIVariant = 1;
+  let AddrMode = !cond(
+    !ne(NAME, !subst("roW", "", NAME))  : 1, // LFI_AM_RoW
+    !ne(NAME, !subst("roX", "", NAME))  : 2, // LFI_AM_RoX
+    !ne(NAME, !subst("pre", "", NAME))  : 3, // LFI_AM_Pre
+    !ne(NAME, !subst("post", "", NAME)) : 4, // LFI_AM_Post
+    1 : 0                                    // LFI_AM_Ui
+  );
+  let RoWInst = !cast<Instruction>(
+    !subst("ui", "",
+    !subst("pre", "",
+    !subst("post", "",
+    !subst("roX", "",
+    !subst("roW", "", NAME))))) # "roW"
+  );
+}
+
+class LFILoadStoreRO<bits<2> sz, bit V> : LFIScalarVariant {
+  let IsLFIMem = 1;
+  let BaseIdx = 1;
+  let OffsetIdx = 2;
+  let HasOffset = 1;
+}
+
+class LFILaneBaseStore : LFIInstruction {
+  let IsLFIMem = 1;
+  let BaseIdx = 2;
+}
+
+class LFILaneBaseLoadTied : LFIInstruction {
+  let IsLFIMem = 1;
+  let BaseIdx = 3;
+}
+
+class LFILanePostStore<int scale> : LFIInstruction {
+  let IsLFIMem = 1;
+  let BaseIdx = 3;
+  let OffsetIdx = 4;
+  let HasOffset = 1;
+  let IsPrePost = 1;
+  let HasSIMDPost = 1;
+  let BaseInst = !cast<Instruction>(!subst("_POST", "", NAME));
+  let NaturalOffset = !mul(
+    scale,
+    !cond(
+      !ne(NAME, !subst("LD2", "", !subst("ST2", "", NAME))) : 2,
+      !ne(NAME, !subst("LD3", "", !subst("ST3", "", NAME))) : 3,
+      !ne(NAME, !subst("LD4", "", !subst("ST4", "", NAME))) : 4,
+      1 : 1
+    )
+  );
+}
+
+class LFILanePostLoadTied<int scale> : LFIInstruction {
+  let IsLFIMem = 1;
+  let BaseIdx = 4;
+  let OffsetIdx = 5;
+  let HasOffset = 1;
+  let IsPrePost = 1;
+  let HasSIMDPost = 1;
+  let BaseInst = !cast<Instruction>(!subst("_POST", "", NAME));
+  let NaturalOffset = !mul(
+    scale,
+    !cond(
+      !ne(NAME, !subst("LD2", "", !subst("ST2", "", NAME))) : 2,
+      !ne(NAME, !subst("LD3", "", !subst("ST3", "", NAME))) : 3,
+      !ne(NAME, !subst("LD4", "", !subst("ST4", "", NAME))) : 4,
+      1 : 1
+    )
+  );
+}

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
@@ -69,6 +69,8 @@ enum LFIAddrMode : uint8_t {
 #define GET_PairVariantTable_IMPL
 #define GET_SIMDPostTable_IMPL
 #define GET_MemInfoTable_IMPL
+// The LFI tables defined in AArch64LFI.td are emitted into this file alongside
+// the system operand tables (single -gen-searchable-tables output).
 #include "AArch64GenSystemOperands.inc"
 } // namespace llvm::AArch64
 

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
@@ -124,17 +124,9 @@ static bool isVASysOp(const MCInst &Inst) {
 
 static MCInst replaceRegAt(const MCInst &Inst, unsigned Idx,
                            MCRegister NewReg) {
-  MCInst New;
-  New.setOpcode(Inst.getOpcode());
-  New.setLoc(Inst.getLoc());
-  for (unsigned I = 0, E = Inst.getNumOperands(); I != E; ++I) {
-    if (I == Idx) {
-      assert(Inst.getOperand(I).isReg());
-      New.addOperand(MCOperand::createReg(NewReg));
-    } else {
-      New.addOperand(Inst.getOperand(I));
-    }
-  }
+  MCInst New = Inst;
+  assert(New.getOperand(Idx).isReg());
+  New.getOperand(Idx).setReg(NewReg);
   return New;
 }
 

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
@@ -27,24 +27,24 @@ using namespace llvm;
 
 namespace llvm::AArch64 {
 struct LFIVariantEntry {
-  unsigned Inst;
+  unsigned LFIInst;
   uint8_t AddrMode;
   uint8_t Log2Size;
   unsigned RoWInst;
 };
 struct PairVariantEntry {
-  unsigned Inst;
+  unsigned LFIInst;
   bool IsPre;
   uint8_t Scale;
   unsigned BaseInst;
 };
 struct SIMDPostEntry {
-  unsigned Inst;
+  unsigned LFIInst;
   uint8_t NaturalOffset;
   unsigned BaseInst;
 };
 struct MemInfoEntry {
-  unsigned Inst;
+  unsigned LFIInst;
   uint8_t BaseIdx;
   uint8_t OffsetIdx;
   bool HasOffset;

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
@@ -614,6 +614,11 @@ void AArch64MCLFIRewriter::rewriteSPModification(const MCInst &Inst,
   if (SkipLoads && SkipStores)
     return emitInst(Inst, Out, STI);
 
+  // Special case: mov sp, xN -> add sp, x27, wN, uxtw
+  if (Inst.getOpcode() == AArch64::ADDXri && Inst.getOperand(2).getImm() == 0 &&
+      Inst.getOperand(3).getImm() == 0)
+    return emitAddMask(AArch64::SP, Inst.getOperand(1).getReg(), Out, STI);
+
   // Redirect SP modification destination to scratch, then sandbox.
   MCInst ModInst = replaceRegAt(Inst, 0, LFIScratchReg);
   emitInst(ModInst, Out, STI);

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
@@ -25,6 +25,53 @@
 
 using namespace llvm;
 
+namespace llvm::AArch64 {
+struct LFIVariantEntry {
+  unsigned Inst;
+  uint8_t AddrMode;
+  uint8_t Log2Size;
+  unsigned RoWInst;
+};
+struct PairVariantEntry {
+  unsigned Inst;
+  bool IsPre;
+  uint8_t Scale;
+  unsigned BaseInst;
+};
+struct SIMDPostEntry {
+  unsigned Inst;
+  uint8_t NaturalOffset;
+  unsigned BaseInst;
+};
+struct MemInfoEntry {
+  unsigned Inst;
+  uint8_t BaseIdx;
+  uint8_t OffsetIdx;
+  bool HasOffset;
+  bool IsPrePost;
+  bool IsLiteral;
+};
+
+// LFI addressing-mode codes (must match AArch64LFI.td's LFI_AM_* defs).
+enum LFIAddrMode : uint8_t {
+  LFI_AM_Ui = 0,
+  LFI_AM_RoW = 1,
+  LFI_AM_RoX = 2,
+  LFI_AM_Pre = 3,
+  LFI_AM_Post = 4,
+};
+
+#define GET_LFIVariantTable_DECL
+#define GET_PairVariantTable_DECL
+#define GET_SIMDPostTable_DECL
+#define GET_MemInfoTable_DECL
+#define GET_LFIVariantTable_IMPL
+#define GET_PairVariantTable_IMPL
+#define GET_SIMDPostTable_IMPL
+#define GET_MemInfoTable_IMPL
+#include "AArch64GenSystemOperands.inc"
+} // namespace llvm::AArch64
+
 // LFI reserved registers.
 static constexpr MCRegister LFIBaseReg = AArch64::X27;
 static constexpr MCRegister LFIAddrReg = AArch64::X28;
@@ -130,34 +177,58 @@ static MCInst replaceRegAt(const MCInst &Inst, unsigned Idx,
   return New;
 }
 
-// Memory instruction information for the base load/store rewriting path.
-// Provides operand indices for the base register and offset, and whether
-// the instruction uses pre/post-indexed addressing.
-struct MemInstInfo {
-  int BaseRegIdx;
-  std::optional<unsigned> OffsetIdx;
-  bool IsPrePost;
-  bool IsLiteral;
-};
-
-// Returns memory instruction info for a given opcode, or std::nullopt if
-// the opcode is not a recognized memory instruction.
-static std::optional<MemInstInfo> getMemInstInfo(unsigned Op);
-
 // AArch64 load/store opcode suffixes used throughout this file:
 //   Ui:  Unsigned immediate offset, scaled by access size: [Xn, #imm].
 //   RoW: Register offset with 32-bit W register: [Xn, Wm, uxtw #shift].
 //   RoX: Register offset with 64-bit X register: [Xn, Xm, lsl #shift].
 
-static unsigned convertUiToRoW(unsigned Op);
-static unsigned convertPreToRoW(unsigned Op);
-static unsigned convertPostToRoW(unsigned Op);
-static unsigned convertRoXToRoW(unsigned Op, unsigned &Shift);
-static bool getRoWShift(unsigned Op, unsigned &Shift);
-static unsigned getPrePostScale(unsigned Op);
+// Scalar load/store variant lookup. If Op is a scalar mem instruction with
+// addressing mode ExpectedMode, returns the RoW variant of the same family.
+// Returns INSTRUCTION_LIST_END otherwise.
+static unsigned convertVariantToRoW(unsigned Op, unsigned ExpectedMode) {
+  const AArch64::LFIVariantEntry *E = AArch64::lookupLFIVariantByOpcode(Op);
+  if (!E || E->AddrMode != ExpectedMode)
+    return AArch64::INSTRUCTION_LIST_END;
+  return E->RoWInst;
+}
+
+static unsigned convertRoXToRoW(unsigned Op, unsigned &Shift) {
+  Shift = 0;
+  const AArch64::LFIVariantEntry *E = AArch64::lookupLFIVariantByOpcode(Op);
+  if (!E || E->AddrMode != AArch64::LFI_AM_RoX)
+    return AArch64::INSTRUCTION_LIST_END;
+  Shift = E->Log2Size;
+  return E->RoWInst;
+}
+
+static bool getRoWShift(unsigned Op, unsigned &Shift) {
+  Shift = 0;
+  const AArch64::LFIVariantEntry *E = AArch64::lookupLFIVariantByOpcode(Op);
+  if (!E || E->AddrMode != AArch64::LFI_AM_RoW)
+    return false;
+  Shift = E->Log2Size;
+  return true;
+}
+
+// Pre/post-index conversion to base form. Both LDP/STP pair pre/post forms and
+// SIMD post-index forms come from generated lookup tables. The pair table sets
+// IsPre to distinguish pre-index from post-index. The SIMD table is
+// post-index-only so IsNoOffset is set to indicate the demoted base form takes
+// no immediate offset.
 static unsigned convertPrePostToBase(unsigned Op, bool &IsPre,
-                                     bool &IsNoOffset);
-static int getSIMDNaturalOffset(unsigned Op);
+                                     bool &IsNoOffset) {
+  IsPre = false;
+  IsNoOffset = false;
+  if (const auto *E = AArch64::lookupPairVariantByOpcode(Op)) {
+    IsPre = E->IsPre;
+    return E->BaseInst;
+  }
+  if (const auto *E = AArch64::lookupSIMDPostByOpcode(Op)) {
+    IsNoOffset = true;
+    return E->BaseInst;
+  }
+  return AArch64::INSTRUCTION_LIST_END;
+}
 
 bool AArch64MCLFIRewriter::mayModifySP(const MCInst &Inst) const {
   return mayModifyRegister(Inst, AArch64::SP);
@@ -395,7 +466,8 @@ bool AArch64MCLFIRewriter::rewriteLoadStoreRoW(const MCInst &Inst,
 
   // Case 1: Indexed load/store with zero immediate offset.
   // ldr xN, [xM, #0] -> ldr xN, [x27, wM, uxtw]
-  if ((MemOp = convertUiToRoW(Op)) != AArch64::INSTRUCTION_LIST_END) {
+  if ((MemOp = convertVariantToRoW(Op, AArch64::LFI_AM_Ui)) !=
+      AArch64::INSTRUCTION_LIST_END) {
     MCRegister BaseReg = Inst.getOperand(1).getReg();
     if (BaseReg == AArch64::SP)
       return false;
@@ -409,7 +481,8 @@ bool AArch64MCLFIRewriter::rewriteLoadStoreRoW(const MCInst &Inst,
 
   // Case 2: Pre-index load/store with writeback.
   // ldr xN, [xM, #imm]! -> add xM, xM, #imm; ldr xN, [x27, wM, uxtw]
-  if ((MemOp = convertPreToRoW(Op)) != AArch64::INSTRUCTION_LIST_END) {
+  if ((MemOp = convertVariantToRoW(Op, AArch64::LFI_AM_Pre)) !=
+      AArch64::INSTRUCTION_LIST_END) {
     MCRegister BaseReg = Inst.getOperand(2).getReg();
     if (BaseReg == AArch64::SP)
       return false;
@@ -421,7 +494,8 @@ bool AArch64MCLFIRewriter::rewriteLoadStoreRoW(const MCInst &Inst,
 
   // Case 3: Post-index load/store.
   // ldr xN, [xM], #imm -> ldr xN, [x27, wM, uxtw]; add xM, xM, #imm
-  if ((MemOp = convertPostToRoW(Op)) != AArch64::INSTRUCTION_LIST_END) {
+  if ((MemOp = convertVariantToRoW(Op, AArch64::LFI_AM_Post)) !=
+      AArch64::INSTRUCTION_LIST_END) {
     MCRegister BaseReg = Inst.getOperand(2).getReg();
     if (BaseReg == AArch64::SP)
       return false;
@@ -484,7 +558,7 @@ void AArch64MCLFIRewriter::rewriteLoadStoreBase(const MCInst &Inst,
                                                 MCStreamer &Out,
                                                 const MCSubtargetInfo &STI) {
   unsigned Opcode = Inst.getOpcode();
-  auto Info = getMemInstInfo(Opcode);
+  const AArch64::MemInfoEntry *Info = AArch64::lookupMemInfoByOpcode(Opcode);
 
   if (!Info)
     return error(Inst, "unknown addressing mode for memory instruction in LFI");
@@ -492,15 +566,15 @@ void AArch64MCLFIRewriter::rewriteLoadStoreBase(const MCInst &Inst,
   if (Info->IsLiteral)
     return error(Inst, "PC-relative literal loads are not supported in LFI");
 
-  MCRegister BaseReg = Inst.getOperand(Info->BaseRegIdx).getReg();
+  MCRegister BaseReg = Inst.getOperand(Info->BaseIdx).getReg();
 
   // Stack accesses don't need address sandboxing, except when sp is modified
   // with a non-zero register post-index operand.
   bool BaseIsSP = BaseReg == AArch64::SP;
   if (BaseIsSP) {
-    if (!Info->OffsetIdx || !Inst.getOperand(*Info->OffsetIdx).isReg())
+    if (!Info->HasOffset || !Inst.getOperand(Info->OffsetIdx).isReg())
       return emitInst(Inst, Out, STI);
-    MCRegister OffReg = Inst.getOperand(*Info->OffsetIdx).getReg();
+    MCRegister OffReg = Inst.getOperand(Info->OffsetIdx).getReg();
     if (OffReg == AArch64::XZR || OffReg == AArch64::WZR)
       return emitInst(Inst, Out, STI);
   }
@@ -511,7 +585,7 @@ void AArch64MCLFIRewriter::rewriteLoadStoreBase(const MCInst &Inst,
 
   if (!Info->IsPrePost) {
     // Non-pre/post instruction: replace the base register operand.
-    MCInst NewInst = replaceRegAt(Inst, Info->BaseRegIdx, LFIAddrReg);
+    MCInst NewInst = replaceRegAt(Inst, Info->BaseIdx, LFIAddrReg);
     emitInst(NewInst, Out, STI);
     return;
   }
@@ -529,7 +603,7 @@ void AArch64MCLFIRewriter::rewriteLoadStoreBase(const MCInst &Inst,
   NewInst.setLoc(Inst.getLoc());
 
   // Skip writeback operand (operand 0) and copy data operands up to base.
-  for (int I = 1; I < Info->BaseRegIdx; ++I)
+  for (int I = 1; I < Info->BaseIdx; ++I)
     NewInst.addOperand(Inst.getOperand(I));
 
   // Add the access base register (LFIAddrReg or SP).
@@ -537,32 +611,35 @@ void AArch64MCLFIRewriter::rewriteLoadStoreBase(const MCInst &Inst,
   NewInst.addOperand(MCOperand::createReg(AccessBase));
 
   // For pre-index, include the offset; for post-index, use zero.
-  if (IsPre && Info->OffsetIdx)
-    NewInst.addOperand(Inst.getOperand(*Info->OffsetIdx));
+  if (IsPre && Info->HasOffset)
+    NewInst.addOperand(Inst.getOperand(Info->OffsetIdx));
   else if (!IsNoOffset)
     NewInst.addOperand(MCOperand::createImm(0));
 
   emitInst(NewInst, Out, STI);
 
-  if (!Info->OffsetIdx)
+  if (!Info->HasOffset)
     return;
 
   // Update the base register with the offset. If the base is SP, a register
   // offset must be sandboxed (the result is otherwise unbounded), and ADDXrs
   // cannot take SP, so the extended-register form via the scratch register is
   // used.
-  const MCOperand &OffsetOp = Inst.getOperand(*Info->OffsetIdx);
+  const MCOperand &OffsetOp = Inst.getOperand(Info->OffsetIdx);
   if (OffsetOp.isImm()) {
-    int64_t Scale = getPrePostScale(Opcode);
+    // Pair pre/post immediates are scaled by element size; other pre/post
+    // forms (scalar, SIMD) use the raw immediate (scale = 1).
+    int64_t Scale = 1;
+    if (const auto *E = AArch64::lookupPairVariantByOpcode(Opcode))
+      Scale = E->Scale;
     int64_t Offset = OffsetOp.getImm() * Scale;
     emitAddImm(BaseReg, BaseReg, Offset, Out, STI);
   } else if (OffsetOp.isReg()) {
     // SIMD post-index uses a register offset (XZR for natural offset).
     MCRegister OffReg = OffsetOp.getReg();
     if (OffReg == AArch64::XZR) {
-      int NaturalOffset = getSIMDNaturalOffset(Opcode);
-      if (NaturalOffset > 0)
-        emitAddImm(BaseReg, BaseReg, NaturalOffset, Out, STI);
+      if (const auto *E = AArch64::lookupSIMDPostByOpcode(Opcode))
+        emitAddImm(BaseReg, BaseReg, E->NaturalOffset, Out, STI);
     } else if (OffReg != AArch64::WZR) {
       if (BaseIsSP) {
         emitAddRegExtend(LFIScratchReg, AArch64::SP, OffReg, AArch64_AM::UXTX,
@@ -702,9 +779,11 @@ void AArch64MCLFIRewriter::doRewriteInst(const MCInst &Inst, MCStreamer &Out,
 // This function is made available to the size estimator so that it can
 // classify Pre/Post-index instructions.
 bool llvm::isLFIPrePostMemAccess(unsigned Opcode) {
-  if (convertPreToRoW(Opcode) != AArch64::INSTRUCTION_LIST_END)
+  if (convertVariantToRoW(Opcode, AArch64::LFI_AM_Pre) !=
+      AArch64::INSTRUCTION_LIST_END)
     return true;
-  if (convertPostToRoW(Opcode) != AArch64::INSTRUCTION_LIST_END)
+  if (convertVariantToRoW(Opcode, AArch64::LFI_AM_Post) !=
+      AArch64::INSTRUCTION_LIST_END)
     return true;
   bool IsPre, IsNoOffset;
   if (convertPrePostToBase(Opcode, IsPre, IsNoOffset) !=
@@ -725,541 +804,4 @@ bool AArch64MCLFIRewriter::rewriteInst(const MCInst &Inst, MCStreamer &Out,
 
   Guard = false;
   return true;
-}
-
-// Opcode X-macro Tables
-//
-// These macros define groups of related opcodes and are used to generate
-// multiple switch tables without repetition. Each macro takes a callback X and
-// invokes X(NAME, VALUE) for each entry.
-
-// Scalar memory ops that have ui, pre, post, roX, and roW variants.
-// PRFM is excluded because it has no pre/post forms.
-// The second column is the log2 element size (shift for scaled addressing).
-#define SCALAR_MEM_OPS(X)                                                      \
-  X(LDRBB, 0)                                                                  \
-  X(LDRB, 0)                                                                   \
-  X(LDRSBW, 0)                                                                 \
-  X(LDRSBX, 0)                                                                 \
-  X(STRBB, 0)                                                                  \
-  X(STRB, 0)                                                                   \
-  X(LDRHH, 1)                                                                  \
-  X(LDRH, 1)                                                                   \
-  X(LDRSHW, 1)                                                                 \
-  X(LDRSHX, 1)                                                                 \
-  X(STRHH, 1)                                                                  \
-  X(STRH, 1)                                                                   \
-  X(LDRSW, 2)                                                                  \
-  X(LDRS, 2)                                                                   \
-  X(LDRW, 2)                                                                   \
-  X(STRS, 2)                                                                   \
-  X(STRW, 2)                                                                   \
-  X(LDRD, 3)                                                                   \
-  X(LDRX, 3)                                                                   \
-  X(STRD, 3)                                                                   \
-  X(STRX, 3)                                                                   \
-  X(LDRQ, 4)                                                                   \
-  X(STRQ, 4)
-
-// LDP/STP pair ops. The second column is the scale factor for pre/post
-// immediates.
-#define PAIR_OPS(X)                                                            \
-  X(LDPD, 8)                                                                   \
-  X(LDPQ, 16)                                                                  \
-  X(LDPSW, 4)                                                                  \
-  X(LDPS, 4)                                                                   \
-  X(LDPW, 4)                                                                   \
-  X(LDPX, 8)                                                                   \
-  X(STPD, 8)                                                                   \
-  X(STPQ, 16)                                                                  \
-  X(STPS, 4)                                                                   \
-  X(STPW, 4)                                                                   \
-  X(STPX, 8)
-
-// SIMD post-index ops, split into three groups by operand layout.
-// The second column is the natural byte offset for post-index.
-
-// Lane stores: Vt, idx, [Rn] (base=2) / wback, Vt, idx, [Rn], Xm (base=3).
-
-// clang-format off
-#define SIMD_LANE_STORE_OPS(X)                                                 \
-  X(ST1i8, 1) X(ST1i16, 2) X(ST1i32,  4) X(ST1i64,  8)                         \
-  X(ST2i8, 2) X(ST2i16, 4) X(ST2i32,  8) X(ST2i64, 16)                         \
-  X(ST3i8, 3) X(ST3i16, 6) X(ST3i32, 12) X(ST3i64, 24)                         \
-  X(ST4i8, 4) X(ST4i16, 8) X(ST4i32, 16) X(ST4i64, 32)
-
-// Lane loads: Vt(out), Vt(tied), idx, [Rn] (base=3) /
-//             wback, Vt(out), Vt(tied), idx, [Rn], Xm (base=4).
-#define SIMD_LANE_LOAD_OPS(X)                                                  \
-  X(LD1i8, 1) X(LD1i16, 2) X(LD1i32,  4) X(LD1i64,  8)                         \
-  X(LD2i8, 2) X(LD2i16, 4) X(LD2i32,  8) X(LD2i64, 16)                         \
-  X(LD3i8, 3) X(LD3i16, 6) X(LD3i32, 12) X(LD3i64, 24)                         \
-  X(LD4i8, 4) X(LD4i16, 8) X(LD4i32, 16) X(LD4i64, 32)
-
-// Multiple structure and replicate: Vt, [Rn] (base=1) /
-//                                   wback, Vt, [Rn], Xm (base=2).
-// Each line pairs the LD and ST variants (replicates are LD-only).
-#define SIMD_MULTI_OPS(X)                                                      \
-  /* Replicate loads (LD only). */                                             \
-  X(LD1Rv8b,  1) X(LD1Rv16b,  1) X(LD1Rv4h,  2) X(LD1Rv8h,  2)                 \
-  X(LD1Rv2s,  4) X(LD1Rv4s,   4) X(LD1Rv1d,  8) X(LD1Rv2d,  8)                 \
-  X(LD2Rv8b,  2) X(LD2Rv16b,  2) X(LD2Rv4h,  4) X(LD2Rv8h,  4)                 \
-  X(LD2Rv2s,  8) X(LD2Rv4s,   8) X(LD2Rv1d, 16) X(LD2Rv2d, 16)                 \
-  X(LD3Rv8b,  3) X(LD3Rv16b,  3) X(LD3Rv4h,  6) X(LD3Rv8h,  6)                 \
-  X(LD3Rv2s, 12) X(LD3Rv4s,  12) X(LD3Rv1d, 24) X(LD3Rv2d, 24)                 \
-  X(LD4Rv8b,  4) X(LD4Rv16b,  4) X(LD4Rv4h,  8) X(LD4Rv8h,  8)                 \
-  X(LD4Rv2s, 16) X(LD4Rv4s,  16) X(LD4Rv1d, 32) X(LD4Rv2d, 32)                 \
-  /* LD1/ST1 One register. */                                                  \
-  X(LD1Onev8b, 8) X(LD1Onev16b, 16)                                            \
-  X(LD1Onev4h, 8) X(LD1Onev8h,  16)                                            \
-  X(LD1Onev2s, 8) X(LD1Onev4s,  16)                                            \
-  X(LD1Onev1d, 8) X(LD1Onev2d,  16)                                            \
-  X(ST1Onev8b, 8) X(ST1Onev16b, 16)                                            \
-  X(ST1Onev4h, 8) X(ST1Onev8h,  16)                                            \
-  X(ST1Onev2s, 8) X(ST1Onev4s,  16)                                            \
-  X(ST1Onev1d, 8) X(ST1Onev2d,  16)                                            \
-  /* LD1/ST1 Two registers. */                                                 \
-  X(LD1Twov8b, 16) X(LD1Twov16b, 32)                                           \
-  X(LD1Twov4h, 16) X(LD1Twov8h,  32)                                           \
-  X(LD1Twov2s, 16) X(LD1Twov4s,  32)                                           \
-  X(LD1Twov1d, 16) X(LD1Twov2d,  32)                                           \
-  X(ST1Twov8b, 16) X(ST1Twov16b, 32)                                           \
-  X(ST1Twov4h, 16) X(ST1Twov8h,  32)                                           \
-  X(ST1Twov2s, 16) X(ST1Twov4s,  32)                                           \
-  X(ST1Twov1d, 16) X(ST1Twov2d,  32)                                           \
-  /* LD1/ST1 Three registers. */                                               \
-  X(LD1Threev8b, 24) X(LD1Threev16b, 48)                                       \
-  X(LD1Threev4h, 24) X(LD1Threev8h,  48)                                       \
-  X(LD1Threev2s, 24) X(LD1Threev4s,  48)                                       \
-  X(LD1Threev1d, 24) X(LD1Threev2d,  48)                                       \
-  X(ST1Threev8b, 24) X(ST1Threev16b, 48)                                       \
-  X(ST1Threev4h, 24) X(ST1Threev8h,  48)                                       \
-  X(ST1Threev2s, 24) X(ST1Threev4s,  48)                                       \
-  X(ST1Threev1d, 24) X(ST1Threev2d,  48)                                       \
-  /* LD1/ST1 Four registers. */                                                \
-  X(LD1Fourv8b, 32) X(LD1Fourv16b, 64)                                         \
-  X(LD1Fourv4h, 32) X(LD1Fourv8h,  64)                                         \
-  X(LD1Fourv2s, 32) X(LD1Fourv4s,  64)                                         \
-  X(LD1Fourv1d, 32) X(LD1Fourv2d,  64)                                         \
-  X(ST1Fourv8b, 32) X(ST1Fourv16b, 64)                                         \
-  X(ST1Fourv4h, 32) X(ST1Fourv8h,  64)                                         \
-  X(ST1Fourv2s, 32) X(ST1Fourv4s,  64)                                         \
-  X(ST1Fourv1d, 32) X(ST1Fourv2d,  64)                                         \
-  /* LD2/ST2 Two registers. */                                                 \
-  X(LD2Twov8b, 16) X(LD2Twov16b, 32)                                           \
-  X(LD2Twov4h, 16) X(LD2Twov8h,  32)                                           \
-  X(LD2Twov2s, 16) X(LD2Twov4s,  32) X(LD2Twov2d, 32)                          \
-  X(ST2Twov8b, 16) X(ST2Twov16b, 32)                                           \
-  X(ST2Twov4h, 16) X(ST2Twov8h,  32)                                           \
-  X(ST2Twov2s, 16) X(ST2Twov4s,  32) X(ST2Twov2d, 32)                          \
-  /* LD3/ST3 Three registers. */                                               \
-  X(LD3Threev8b, 24) X(LD3Threev16b, 48)                                       \
-  X(LD3Threev4h, 24) X(LD3Threev8h,  48)                                       \
-  X(LD3Threev2s, 24) X(LD3Threev4s,  48) X(LD3Threev2d, 48)                    \
-  X(ST3Threev8b, 24) X(ST3Threev16b, 48)                                       \
-  X(ST3Threev4h, 24) X(ST3Threev8h,  48)                                       \
-  X(ST3Threev2s, 24) X(ST3Threev4s,  48) X(ST3Threev2d, 48)                    \
-  /* LD4/ST4 Four registers. */                                                \
-  X(LD4Fourv8b, 32) X(LD4Fourv16b, 64)                                         \
-  X(LD4Fourv4h, 32) X(LD4Fourv8h,  64)                                         \
-  X(LD4Fourv2s, 32) X(LD4Fourv4s,  64) X(LD4Fourv2d,  64)                      \
-  X(ST4Fourv8b, 32) X(ST4Fourv16b, 64)                                         \
-  X(ST4Fourv4h, 32) X(ST4Fourv8h,  64)                                         \
-  X(ST4Fourv2s, 32) X(ST4Fourv4s,  64) X(ST4Fourv2d,  64)
-// clang-format on
-
-// Union of all SIMD post-index ops.
-#define SIMD_POST_OPS(X)                                                       \
-  SIMD_LANE_STORE_OPS(X)                                                       \
-  SIMD_LANE_LOAD_OPS(X)                                                        \
-  SIMD_MULTI_OPS(X)
-
-// Memory Instruction Info Table
-//
-// Returns information about how to find the base register and offset operands
-// in a memory instruction, and whether it uses pre/post-indexed addressing.
-// Used by rewriteLoadStoreBase as a fallback when RoW conversion isn't
-// possible.
-static std::optional<MemInstInfo> getMemInstInfo(unsigned Op) {
-  switch (Op) {
-  default:
-    return std::nullopt;
-
-  // PC-relative literal loads: Rt, label
-  case AArch64::LDRWl:
-  case AArch64::LDRXl:
-  case AArch64::LDRSWl:
-  case AArch64::LDRSl:
-  case AArch64::LDRDl:
-  case AArch64::LDRQl:
-  case AArch64::PRFMl:
-    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
-    return MemInstInfo{0, std::nullopt, false, true};
-
-    // Scalar indexed/unscaled/register-offset: Rt, [Rn, ...]
-#define X(NAME, S)                                                             \
-  case AArch64::NAME##ui:                                                      \
-  case AArch64::NAME##roW:                                                     \
-  case AArch64::NAME##roX:
-    SCALAR_MEM_OPS(X)
-#undef X
-  case AArch64::PRFMui:
-  case AArch64::PRFMroW:
-  case AArch64::PRFMroX:
-  // Unscaled variants.
-  case AArch64::LDURBBi:
-  case AArch64::LDURBi:
-  case AArch64::LDURDi:
-  case AArch64::LDURHHi:
-  case AArch64::LDURHi:
-  case AArch64::LDURQi:
-  case AArch64::LDURSBWi:
-  case AArch64::LDURSBXi:
-  case AArch64::LDURSHWi:
-  case AArch64::LDURSHXi:
-  case AArch64::LDURSWi:
-  case AArch64::LDURSi:
-  case AArch64::LDURWi:
-  case AArch64::LDURXi:
-  case AArch64::STURBBi:
-  case AArch64::STURBi:
-  case AArch64::STURDi:
-  case AArch64::STURHHi:
-  case AArch64::STURHi:
-  case AArch64::STURQi:
-  case AArch64::STURSi:
-  case AArch64::STURWi:
-  case AArch64::STURXi:
-  case AArch64::PRFUMi:
-    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
-    return MemInstInfo{1, 2, false, false};
-
-    // Scalar pre/post-index: wback, Rt, [Rn], #imm
-#define X(NAME, S)                                                             \
-  case AArch64::NAME##pre:                                                     \
-  case AArch64::NAME##post:
-    SCALAR_MEM_OPS(X)
-#undef X
-    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
-    return MemInstInfo{2, 3, true, false};
-
-  // Exclusive/acquire loads: Rt, [Rn]
-  case AArch64::LDXRB:
-  case AArch64::LDXRH:
-  case AArch64::LDXRW:
-  case AArch64::LDXRX:
-  case AArch64::LDAXRB:
-  case AArch64::LDAXRH:
-  case AArch64::LDAXRW:
-  case AArch64::LDAXRX:
-  case AArch64::LDARB:
-  case AArch64::LDARH:
-  case AArch64::LDARW:
-  case AArch64::LDARX:
-  case AArch64::LDLARB:
-  case AArch64::LDLARH:
-  case AArch64::LDLARW:
-  case AArch64::LDLARX:
-  // RCPC loads: Rt, [Rn]
-  case AArch64::LDAPRB:
-  case AArch64::LDAPRH:
-  case AArch64::LDAPRW:
-  case AArch64::LDAPRX:
-  // Store-release: Rt, [Rn]
-  case AArch64::STLRB:
-  case AArch64::STLRH:
-  case AArch64::STLRW:
-  case AArch64::STLRX:
-  case AArch64::STLLRB:
-  case AArch64::STLLRH:
-  case AArch64::STLLRW:
-  case AArch64::STLLRX:
-    // SIMD multiple/replicate (base form): Vt, [Rn]
-#define X(NAME, OFF) case AArch64::NAME:
-    SIMD_MULTI_OPS(X)
-#undef X
-    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
-    return MemInstInfo{1, std::nullopt, false, false};
-
-  // Exclusive stores: Ws, Rt, [Rn]
-  case AArch64::STXRB:
-  case AArch64::STXRH:
-  case AArch64::STXRW:
-  case AArch64::STXRX:
-  case AArch64::STLXRB:
-  case AArch64::STLXRH:
-  case AArch64::STLXRW:
-  case AArch64::STLXRX:
-    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
-    return MemInstInfo{2, std::nullopt, false, false};
-
-  // Exclusive pair loads: Rt, Rt2, [Rn]
-  case AArch64::LDXPW:
-  case AArch64::LDXPX:
-  case AArch64::LDAXPW:
-  case AArch64::LDAXPX:
-    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
-    return MemInstInfo{2, std::nullopt, false, false};
-
-    // Pair indexed loads/stores: Rt, Rt2, [Rn, #imm]
-#define X(NAME, SCALE) case AArch64::NAME##i:
-    PAIR_OPS(X)
-#undef X
-  case AArch64::LDNPDi:
-  case AArch64::LDNPQi:
-  case AArch64::LDNPSi:
-  case AArch64::LDNPWi:
-  case AArch64::LDNPXi:
-  case AArch64::STNPDi:
-  case AArch64::STNPQi:
-  case AArch64::STNPSi:
-  case AArch64::STNPWi:
-  case AArch64::STNPXi:
-    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
-    return MemInstInfo{2, 3, false, false};
-
-    // CAS: Rs(out), Rs(in, tied), Rt, [Rn]
-#define CAS_VARIANTS(NAME)                                                     \
-  case AArch64::NAME##B:                                                       \
-  case AArch64::NAME##H:                                                       \
-  case AArch64::NAME##W:                                                       \
-  case AArch64::NAME##X:
-    CAS_VARIANTS(CAS)
-    CAS_VARIANTS(CASA)
-    CAS_VARIANTS(CASL)
-    CAS_VARIANTS(CASAL)
-#undef CAS_VARIANTS
-    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
-    return MemInstInfo{3, std::nullopt, false, false};
-
-    // LSE atomics: Rs, Rt, [Rn] - all 16 size/ordering variants per operation.
-#define LSE_VARIANTS(NAME)                                                     \
-  case AArch64::NAME##B:                                                       \
-  case AArch64::NAME##H:                                                       \
-  case AArch64::NAME##W:                                                       \
-  case AArch64::NAME##X:                                                       \
-  case AArch64::NAME##AB:                                                      \
-  case AArch64::NAME##AH:                                                      \
-  case AArch64::NAME##AW:                                                      \
-  case AArch64::NAME##AX:                                                      \
-  case AArch64::NAME##LB:                                                      \
-  case AArch64::NAME##LH:                                                      \
-  case AArch64::NAME##LW:                                                      \
-  case AArch64::NAME##LX:                                                      \
-  case AArch64::NAME##ALB:                                                     \
-  case AArch64::NAME##ALH:                                                     \
-  case AArch64::NAME##ALW:                                                     \
-  case AArch64::NAME##ALX:
-    LSE_VARIANTS(LDADD)
-    LSE_VARIANTS(LDCLR)
-    LSE_VARIANTS(LDEOR)
-    LSE_VARIANTS(LDSET)
-    LSE_VARIANTS(LDSMAX)
-    LSE_VARIANTS(LDSMIN)
-    LSE_VARIANTS(LDUMAX)
-    LSE_VARIANTS(LDUMIN)
-    LSE_VARIANTS(SWP)
-#undef LSE_VARIANTS
-    // SIMD lane stores (base form): Vt, idx, [Rn]
-#define X(NAME, OFF) case AArch64::NAME:
-    SIMD_LANE_STORE_OPS(X)
-#undef X
-    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
-    return MemInstInfo{2, std::nullopt, false, false};
-
-    // SIMD lane loads (base form): Vt(out), Vt(tied), idx, [Rn]
-#define X(NAME, OFF) case AArch64::NAME:
-    SIMD_LANE_LOAD_OPS(X)
-#undef X
-    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
-    return MemInstInfo{3, std::nullopt, false, false};
-
-  // Exclusive store pairs: Ws, Rt, Rt2, [Rn]
-  case AArch64::STXPW:
-  case AArch64::STXPX:
-  case AArch64::STLXPW:
-  case AArch64::STLXPX:
-    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
-    return MemInstInfo{3, std::nullopt, false, false};
-
-    // Pair pre/post-index: wback, Rt, Rt2, [Rn, #imm]! / [Rn], #imm
-#define X(NAME, SCALE)                                                         \
-  case AArch64::NAME##pre:                                                     \
-  case AArch64::NAME##post:
-    PAIR_OPS(X)
-#undef X
-    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
-    return MemInstInfo{3, 4, true, false};
-
-  // CASP: Ws_Ws2(out), Ws_Ws2(in, tied), Wt_Wt2, [Rn]
-  case AArch64::CASPW:
-  case AArch64::CASPX:
-  case AArch64::CASPAW:
-  case AArch64::CASPAX:
-  case AArch64::CASPLW:
-  case AArch64::CASPLX:
-  case AArch64::CASPALW:
-  case AArch64::CASPALX:
-    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
-    return MemInstInfo{3, std::nullopt, false, false};
-
-    // SIMD multiple/replicate post-index: wback, Vt, [Rn], Xm
-#define X(NAME, OFF) case AArch64::NAME##_POST:
-    SIMD_MULTI_OPS(X)
-#undef X
-    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
-    return MemInstInfo{2, 3, true, false};
-
-    // SIMD lane store post-index: wback, Vt, idx, [Rn], Xm
-#define X(NAME, OFF) case AArch64::NAME##_POST:
-    SIMD_LANE_STORE_OPS(X)
-#undef X
-    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
-    return MemInstInfo{3, 4, true, false};
-
-    // SIMD lane load post-index: wback, Vt(out), Vt(tied), idx, [Rn], Xm
-#define X(NAME, OFF) case AArch64::NAME##_POST:
-    SIMD_LANE_LOAD_OPS(X)
-#undef X
-    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
-    return MemInstInfo{4, 5, true, false};
-  }
-}
-
-// RoW (Register-offset-W) Opcode Conversion Tables
-//
-// These tables convert various load/store addressing modes to the
-// register-offset-W form ([X27, Wn, uxtw]) which provides sandboxing in a
-// single instruction by zero-extending the 32-bit offset register.
-//
-// All scalar load/store instructions that support RoW addressing are listed
-// here. Each entry is (NAME, SHIFT) where NAME is the opcode base (e.g. LDRX)
-// and SHIFT is the log2 element size used for scaled addressing.
-static unsigned convertUiToRoW(unsigned Op) {
-  switch (Op) {
-#define X(NAME, S)                                                             \
-  case AArch64::NAME##ui:                                                      \
-    return AArch64::NAME##roW;
-    SCALAR_MEM_OPS(X)
-#undef X
-  case AArch64::PRFMui:
-    return AArch64::PRFMroW;
-  default:
-    return AArch64::INSTRUCTION_LIST_END;
-  }
-}
-
-static unsigned convertPreToRoW(unsigned Op) {
-  switch (Op) {
-#define X(NAME, S)                                                             \
-  case AArch64::NAME##pre:                                                     \
-    return AArch64::NAME##roW;
-    SCALAR_MEM_OPS(X)
-#undef X
-  default:
-    return AArch64::INSTRUCTION_LIST_END;
-  }
-}
-
-static unsigned convertPostToRoW(unsigned Op) {
-  switch (Op) {
-#define X(NAME, S)                                                             \
-  case AArch64::NAME##post:                                                    \
-    return AArch64::NAME##roW;
-    SCALAR_MEM_OPS(X)
-#undef X
-  default:
-    return AArch64::INSTRUCTION_LIST_END;
-  }
-}
-
-static unsigned convertRoXToRoW(unsigned Op, unsigned &Shift) {
-  Shift = 0;
-  switch (Op) {
-#define X(NAME, S)                                                             \
-  case AArch64::NAME##roX:                                                     \
-    Shift = S;                                                                 \
-    return AArch64::NAME##roW;
-    SCALAR_MEM_OPS(X)
-#undef X
-  case AArch64::PRFMroX:
-    Shift = 3;
-    return AArch64::PRFMroW;
-  default:
-    return AArch64::INSTRUCTION_LIST_END;
-  }
-}
-
-static bool getRoWShift(unsigned Op, unsigned &Shift) {
-  Shift = 0;
-  switch (Op) {
-#define X(NAME, S)                                                             \
-  case AArch64::NAME##roW:                                                     \
-    Shift = S;                                                                 \
-    return true;
-    SCALAR_MEM_OPS(X)
-#undef X
-  case AArch64::PRFMroW:
-    Shift = 3;
-    return true;
-  default:
-    return false;
-  }
-}
-
-// Pre/Post-Index to Base Conversion and Natural Offset Tables
-//
-// SIMD post-index instructions are listed once in SIMD_POST_OPS and used to
-// generate both convertPrePostToBase and getSIMDNaturalOffset.
-// Each entry is (NAME, OFFSET) where the post opcode is NAME##_POST, the base
-// opcode is NAME, and OFFSET is the natural byte increment.
-static unsigned convertPrePostToBase(unsigned Op, bool &IsPre,
-                                     bool &IsNoOffset) {
-  IsPre = false;
-  IsNoOffset = false;
-  switch (Op) {
-    // LDP/STP pairs.
-#define X(NAME, SCALE)                                                         \
-  case AArch64::NAME##post:                                                    \
-    return AArch64::NAME##i;                                                   \
-  case AArch64::NAME##pre:                                                     \
-    IsPre = true;                                                              \
-    return AArch64::NAME##i;
-    PAIR_OPS(X)
-#undef X
-    // SIMD post-index.
-#define X(NAME, OFF)                                                           \
-  case AArch64::NAME##_POST:                                                   \
-    IsNoOffset = true;                                                         \
-    return AArch64::NAME;
-    SIMD_POST_OPS(X)
-#undef X
-  default:
-    return AArch64::INSTRUCTION_LIST_END;
-  }
-}
-
-static unsigned getPrePostScale(unsigned Op) {
-  switch (Op) {
-#define X(NAME, SCALE)                                                         \
-  case AArch64::NAME##post:                                                    \
-  case AArch64::NAME##pre:                                                     \
-    return SCALE;
-    PAIR_OPS(X)
-#undef X
-  default:
-    return 1;
-  }
-}
-
-static int getSIMDNaturalOffset(unsigned Op) {
-  switch (Op) {
-#define X(NAME, OFF)                                                           \
-  case AArch64::NAME##_POST:                                                   \
-    return OFF;
-    SIMD_POST_OPS(X)
-#undef X
-  default:
-    return -1;
-  }
 }

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
@@ -143,7 +143,7 @@ static MCInst replaceRegAt(const MCInst &Inst, unsigned Idx,
 // the instruction uses pre/post-indexed addressing.
 struct MemInstInfo {
   int BaseRegIdx;
-  int OffsetIdx; // -1 if no offset operand.
+  std::optional<unsigned> OffsetIdx;
   bool IsPrePost;
   bool IsLiteral;
 };
@@ -441,6 +441,9 @@ bool AArch64MCLFIRewriter::rewriteLoadStoreRoW(const MCInst &Inst,
 
   // Case 4: Register-offset-X load/store.
   // ldr xN, [xM1, xM2] -> add x26, xM1, xM2; ldr xN, [x27, w26, uxtw]
+  //
+  // In this case, even if xM1 is SP we must do a full rewrite, since an
+  // arbitrary register value is being added as the offset.
   unsigned Shift;
   if ((MemOp = convertRoXToRoW(Op, Shift)) != AArch64::INSTRUCTION_LIST_END) {
     MCRegister Reg1 = Inst.getOperand(1).getReg();
@@ -500,82 +503,83 @@ void AArch64MCLFIRewriter::rewriteLoadStoreBase(const MCInst &Inst,
   MCRegister BaseReg = Inst.getOperand(Info->BaseRegIdx).getReg();
 
   // Stack accesses don't need address sandboxing, except when sp is modified
-  // with a register post-index operand.
+  // with a non-zero register post-index operand.
   bool BaseIsSP = BaseReg == AArch64::SP;
   if (BaseIsSP) {
-    if (Info->OffsetIdx < 0 || !Inst.getOperand(Info->OffsetIdx).isReg())
+    if (!Info->OffsetIdx || !Inst.getOperand(*Info->OffsetIdx).isReg())
       return emitInst(Inst, Out, STI);
-    MCRegister OffReg = Inst.getOperand(Info->OffsetIdx).getReg();
+    MCRegister OffReg = Inst.getOperand(*Info->OffsetIdx).getReg();
     if (OffReg == AArch64::XZR || OffReg == AArch64::WZR)
       return emitInst(Inst, Out, STI);
   }
 
   // Guard the base register, unless it is SP.
-  MCRegister AccessBase = BaseIsSP ? AArch64::SP : LFIAddrReg;
   if (!BaseIsSP)
     emitAddMask(LFIAddrReg, BaseReg, Out, STI);
 
-  if (Info->IsPrePost) {
-    bool IsPre = false;
-    bool IsNoOffset = false;
-    unsigned BaseOpcode = convertPrePostToBase(Opcode, IsPre, IsNoOffset);
-
-    if (BaseOpcode != AArch64::INSTRUCTION_LIST_END) {
-      // Demote pre/post-index to base indexed form.
-      MCInst NewInst;
-      NewInst.setOpcode(BaseOpcode);
-      NewInst.setLoc(Inst.getLoc());
-
-      // Skip writeback operand (operand 0) and copy data operands up to base.
-      for (int I = 1; I < Info->BaseRegIdx; ++I)
-        NewInst.addOperand(Inst.getOperand(I));
-
-      // Add the access base register (LFIAddrReg or SP).
-      NewInst.addOperand(MCOperand::createReg(AccessBase));
-
-      // For pre-index, include the offset; for post-index, use zero.
-      if (IsPre && Info->OffsetIdx >= 0)
-        NewInst.addOperand(Inst.getOperand(Info->OffsetIdx));
-      else if (!IsNoOffset)
-        NewInst.addOperand(MCOperand::createImm(0));
-
-      emitInst(NewInst, Out, STI);
-
-      // Update the base register with the offset. If the base is SP, a
-      // register offset must be sandboxed (the result is otherwise
-      // unbounded), and ADDXrs cannot take SP, so the extended-register form
-      // via the scratch register is used.
-      if (Info->OffsetIdx >= 0) {
-        const MCOperand &OffsetOp = Inst.getOperand(Info->OffsetIdx);
-        if (OffsetOp.isImm()) {
-          int64_t Scale = getPrePostScale(Opcode);
-          int64_t Offset = OffsetOp.getImm() * Scale;
-          emitAddImm(BaseReg, BaseReg, Offset, Out, STI);
-        } else if (OffsetOp.isReg()) {
-          // SIMD post-index uses a register offset (XZR for natural offset).
-          MCRegister OffReg = OffsetOp.getReg();
-          if (OffReg == AArch64::XZR) {
-            int NaturalOffset = getSIMDNaturalOffset(Opcode);
-            if (NaturalOffset > 0)
-              emitAddImm(BaseReg, BaseReg, NaturalOffset, Out, STI);
-          } else if (OffReg != AArch64::WZR) {
-            if (BaseIsSP) {
-              emitAddRegExtend(LFIScratchReg, AArch64::SP, OffReg,
-                               AArch64_AM::UXTX, 0, Out, STI);
-              emitAddMask(AArch64::SP, LFIScratchReg, Out, STI);
-            } else {
-              emitAddReg(BaseReg, BaseReg, OffReg, 0, Out, STI);
-            }
-          }
-        }
-      }
-    } else {
-      error(Inst, "unhandled pre/post-index instruction in LFI rewriter");
-    }
-  } else {
+  if (!Info->IsPrePost) {
     // Non-pre/post instruction: replace the base register operand.
     MCInst NewInst = replaceRegAt(Inst, Info->BaseRegIdx, LFIAddrReg);
     emitInst(NewInst, Out, STI);
+    return;
+  }
+
+  bool IsPre = false;
+  bool IsNoOffset = false;
+  unsigned BaseOpcode = convertPrePostToBase(Opcode, IsPre, IsNoOffset);
+
+  if (BaseOpcode == AArch64::INSTRUCTION_LIST_END)
+    return error(Inst, "unhandled pre/post-index instruction in LFI rewriter");
+
+  // Demote pre/post-index to base indexed form.
+  MCInst NewInst;
+  NewInst.setOpcode(BaseOpcode);
+  NewInst.setLoc(Inst.getLoc());
+
+  // Skip writeback operand (operand 0) and copy data operands up to base.
+  for (int I = 1; I < Info->BaseRegIdx; ++I)
+    NewInst.addOperand(Inst.getOperand(I));
+
+  // Add the access base register (LFIAddrReg or SP).
+  MCRegister AccessBase = BaseIsSP ? AArch64::SP : LFIAddrReg;
+  NewInst.addOperand(MCOperand::createReg(AccessBase));
+
+  // For pre-index, include the offset; for post-index, use zero.
+  if (IsPre && Info->OffsetIdx)
+    NewInst.addOperand(Inst.getOperand(*Info->OffsetIdx));
+  else if (!IsNoOffset)
+    NewInst.addOperand(MCOperand::createImm(0));
+
+  emitInst(NewInst, Out, STI);
+
+  if (!Info->OffsetIdx)
+    return;
+
+  // Update the base register with the offset. If the base is SP, a register
+  // offset must be sandboxed (the result is otherwise unbounded), and ADDXrs
+  // cannot take SP, so the extended-register form via the scratch register is
+  // used.
+  const MCOperand &OffsetOp = Inst.getOperand(*Info->OffsetIdx);
+  if (OffsetOp.isImm()) {
+    int64_t Scale = getPrePostScale(Opcode);
+    int64_t Offset = OffsetOp.getImm() * Scale;
+    emitAddImm(BaseReg, BaseReg, Offset, Out, STI);
+  } else if (OffsetOp.isReg()) {
+    // SIMD post-index uses a register offset (XZR for natural offset).
+    MCRegister OffReg = OffsetOp.getReg();
+    if (OffReg == AArch64::XZR) {
+      int NaturalOffset = getSIMDNaturalOffset(Opcode);
+      if (NaturalOffset > 0)
+        emitAddImm(BaseReg, BaseReg, NaturalOffset, Out, STI);
+    } else if (OffReg != AArch64::WZR) {
+      if (BaseIsSP) {
+        emitAddRegExtend(LFIScratchReg, AArch64::SP, OffReg, AArch64_AM::UXTX,
+                         0, Out, STI);
+        emitAddMask(AArch64::SP, LFIScratchReg, Out, STI);
+      } else {
+        emitAddReg(BaseReg, BaseReg, OffReg, 0, Out, STI);
+      }
+    }
   }
 }
 
@@ -892,7 +896,8 @@ static std::optional<MemInstInfo> getMemInstInfo(unsigned Op) {
   case AArch64::LDRDl:
   case AArch64::LDRQl:
   case AArch64::PRFMl:
-    return MemInstInfo{0, -1, false, true};
+    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
+    return MemInstInfo{0, std::nullopt, false, true};
 
     // Scalar indexed/unscaled/register-offset: Rt, [Rn, ...]
 #define X(NAME, S)                                                             \
@@ -929,6 +934,7 @@ static std::optional<MemInstInfo> getMemInstInfo(unsigned Op) {
   case AArch64::STURWi:
   case AArch64::STURXi:
   case AArch64::PRFUMi:
+    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
     return MemInstInfo{1, 2, false, false};
 
     // Scalar pre/post-index: wback, Rt, [Rn], #imm
@@ -937,6 +943,7 @@ static std::optional<MemInstInfo> getMemInstInfo(unsigned Op) {
   case AArch64::NAME##post:
     SCALAR_MEM_OPS(X)
 #undef X
+    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
     return MemInstInfo{2, 3, true, false};
 
   // Exclusive/acquire loads: Rt, [Rn]
@@ -974,7 +981,8 @@ static std::optional<MemInstInfo> getMemInstInfo(unsigned Op) {
 #define X(NAME, OFF) case AArch64::NAME:
     SIMD_MULTI_OPS(X)
 #undef X
-    return MemInstInfo{1, -1, false, false};
+    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
+    return MemInstInfo{1, std::nullopt, false, false};
 
   // Exclusive stores: Ws, Rt, [Rn]
   case AArch64::STXRB:
@@ -985,14 +993,16 @@ static std::optional<MemInstInfo> getMemInstInfo(unsigned Op) {
   case AArch64::STLXRH:
   case AArch64::STLXRW:
   case AArch64::STLXRX:
-    return MemInstInfo{2, -1, false, false};
+    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
+    return MemInstInfo{2, std::nullopt, false, false};
 
   // Exclusive pair loads: Rt, Rt2, [Rn]
   case AArch64::LDXPW:
   case AArch64::LDXPX:
   case AArch64::LDAXPW:
   case AArch64::LDAXPX:
-    return MemInstInfo{2, -1, false, false};
+    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
+    return MemInstInfo{2, std::nullopt, false, false};
 
     // Pair indexed loads/stores: Rt, Rt2, [Rn, #imm]
 #define X(NAME, SCALE) case AArch64::NAME##i:
@@ -1008,6 +1018,7 @@ static std::optional<MemInstInfo> getMemInstInfo(unsigned Op) {
   case AArch64::STNPSi:
   case AArch64::STNPWi:
   case AArch64::STNPXi:
+    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
     return MemInstInfo{2, 3, false, false};
 
     // CAS: Rs(out), Rs(in, tied), Rt, [Rn]
@@ -1021,7 +1032,8 @@ static std::optional<MemInstInfo> getMemInstInfo(unsigned Op) {
     CAS_VARIANTS(CASL)
     CAS_VARIANTS(CASAL)
 #undef CAS_VARIANTS
-    return MemInstInfo{3, -1, false, false};
+    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
+    return MemInstInfo{3, std::nullopt, false, false};
 
     // LSE atomics: Rs, Rt, [Rn] - all 16 size/ordering variants per operation.
 #define LSE_VARIANTS(NAME)                                                     \
@@ -1055,20 +1067,23 @@ static std::optional<MemInstInfo> getMemInstInfo(unsigned Op) {
 #define X(NAME, OFF) case AArch64::NAME:
     SIMD_LANE_STORE_OPS(X)
 #undef X
-    return MemInstInfo{2, -1, false, false};
+    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
+    return MemInstInfo{2, std::nullopt, false, false};
 
     // SIMD lane loads (base form): Vt(out), Vt(tied), idx, [Rn]
 #define X(NAME, OFF) case AArch64::NAME:
     SIMD_LANE_LOAD_OPS(X)
 #undef X
-    return MemInstInfo{3, -1, false, false};
+    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
+    return MemInstInfo{3, std::nullopt, false, false};
 
   // Exclusive store pairs: Ws, Rt, Rt2, [Rn]
   case AArch64::STXPW:
   case AArch64::STXPX:
   case AArch64::STLXPW:
   case AArch64::STLXPX:
-    return MemInstInfo{3, -1, false, false};
+    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
+    return MemInstInfo{3, std::nullopt, false, false};
 
     // Pair pre/post-index: wback, Rt, Rt2, [Rn, #imm]! / [Rn], #imm
 #define X(NAME, SCALE)                                                         \
@@ -1076,6 +1091,7 @@ static std::optional<MemInstInfo> getMemInstInfo(unsigned Op) {
   case AArch64::NAME##post:
     PAIR_OPS(X)
 #undef X
+    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
     return MemInstInfo{3, 4, true, false};
 
   // CASP: Ws_Ws2(out), Ws_Ws2(in, tied), Wt_Wt2, [Rn]
@@ -1087,24 +1103,28 @@ static std::optional<MemInstInfo> getMemInstInfo(unsigned Op) {
   case AArch64::CASPLX:
   case AArch64::CASPALW:
   case AArch64::CASPALX:
-    return MemInstInfo{3, -1, false, false};
+    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
+    return MemInstInfo{3, std::nullopt, false, false};
 
     // SIMD multiple/replicate post-index: wback, Vt, [Rn], Xm
 #define X(NAME, OFF) case AArch64::NAME##_POST:
     SIMD_MULTI_OPS(X)
 #undef X
+    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
     return MemInstInfo{2, 3, true, false};
 
     // SIMD lane store post-index: wback, Vt, idx, [Rn], Xm
 #define X(NAME, OFF) case AArch64::NAME##_POST:
     SIMD_LANE_STORE_OPS(X)
 #undef X
+    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
     return MemInstInfo{3, 4, true, false};
 
     // SIMD lane load post-index: wback, Vt(out), Vt(tied), idx, [Rn], Xm
 #define X(NAME, OFF) case AArch64::NAME##_POST:
     SIMD_LANE_LOAD_OPS(X)
 #undef X
+    // BaseIdx, OffsetIdx, IsPrePost, IsLiteral
     return MemInstInfo{4, 5, true, false};
   }
 }

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
@@ -67,14 +67,20 @@ static bool isPrivilegedTPAccess(const MCInst &Inst) {
   return false;
 }
 
+// Classification functions are limited to Armv8.1-A. Instructions outside of
+// this subset are not guaranteed to be rewritten and as a result may fail LFI
+// verification after compilation.
+
 // Instructions that have mayLoad/mayStore set in TableGen but don't actually
 // perform memory accesses.
-static bool isNotMemAccess(const MCInst &Inst) {
+static bool isFakeMemAccess(const MCInst &Inst) {
   switch (Inst.getOpcode()) {
   case AArch64::DMB:
   case AArch64::DSB:
   case AArch64::ISB:
   case AArch64::HINT:
+    // The range of sub-architectures supported by LFI do not include any load
+    // or store instructions in the HINT space.
     return true;
   default:
     return false;
@@ -122,15 +128,17 @@ static MCInst replaceRegAt(const MCInst &Inst, unsigned Idx,
   New.setOpcode(Inst.getOpcode());
   New.setLoc(Inst.getLoc());
   for (unsigned I = 0, E = Inst.getNumOperands(); I != E; ++I) {
-    if (I == Idx)
+    if (I == Idx) {
+      assert(Inst.getOperand(I).isReg());
       New.addOperand(MCOperand::createReg(NewReg));
-    else
+    } else {
       New.addOperand(Inst.getOperand(I));
+    }
   }
   return New;
 }
 
-// Memory instruction information for the basic load/store rewriting path.
+// Memory instruction information for the base load/store rewriting path.
 // Provides operand indices for the base register and offset, and whether
 // the instruction uses pre/post-indexed addressing.
 struct MemInstInfo {
@@ -144,6 +152,11 @@ struct MemInstInfo {
 // the opcode is not a recognized memory instruction.
 static std::optional<MemInstInfo> getMemInstInfo(unsigned Op);
 
+// AArch64 load/store opcode suffixes used throughout this file:
+//   Ui:  Unsigned immediate offset, scaled by access size: [Xn, #imm].
+//   RoW: Register offset with 32-bit W register: [Xn, Wm, uxtw #shift].
+//   RoX: Register offset with 64-bit X register: [Xn, Xm, lsl #shift].
+
 static unsigned convertUiToRoW(unsigned Op);
 static unsigned convertPreToRoW(unsigned Op);
 static unsigned convertPostToRoW(unsigned Op);
@@ -154,7 +167,7 @@ static unsigned convertPrePostToBase(unsigned Op, bool &IsPre,
                                      bool &IsNoOffset);
 static int getSIMDNaturalOffset(unsigned Op);
 
-bool AArch64MCLFIRewriter::mayModifyStack(const MCInst &Inst) const {
+bool AArch64MCLFIRewriter::mayModifySP(const MCInst &Inst) const {
   return mayModifyRegister(Inst, AArch64::SP);
 }
 
@@ -213,12 +226,14 @@ void AArch64MCLFIRewriter::emitAddImm(MCRegister Dest, MCRegister Src,
   assert(std::abs(Imm) <= 4095);
   MCInst Inst;
   if (Imm >= 0) {
+    // add Dest, Src, Imm
     Inst.setOpcode(AArch64::ADDXri);
     Inst.addOperand(MCOperand::createReg(Dest));
     Inst.addOperand(MCOperand::createReg(Src));
     Inst.addOperand(MCOperand::createImm(Imm));
     Inst.addOperand(MCOperand::createImm(0)); // shift
   } else {
+    // sub Dest, Src, -Imm
     Inst.setOpcode(AArch64::SUBXri);
     Inst.addOperand(MCOperand::createReg(Dest));
     Inst.addOperand(MCOperand::createReg(Src));
@@ -316,7 +331,7 @@ void AArch64MCLFIRewriter::rewriteReturn(const MCInst &Inst, MCStreamer &Out,
 void AArch64MCLFIRewriter::rewriteLRModification(const MCInst &Inst,
                                                  MCStreamer &Out,
                                                  const MCSubtargetInfo &STI) {
-  if (!isNotMemAccess(Inst) &&
+  if (!isFakeMemAccess(Inst) &&
       (mayLoad(Inst) || mayStore(Inst) || mayPrefetch(Inst)))
     rewriteLoadStore(Inst, Out, STI);
   else
@@ -470,9 +485,9 @@ bool AArch64MCLFIRewriter::rewriteLoadStoreRoW(const MCInst &Inst,
   return false;
 }
 
-void AArch64MCLFIRewriter::rewriteLoadStoreBasic(const MCInst &Inst,
-                                                 MCStreamer &Out,
-                                                 const MCSubtargetInfo &STI) {
+void AArch64MCLFIRewriter::rewriteLoadStoreBase(const MCInst &Inst,
+                                                MCStreamer &Out,
+                                                const MCSubtargetInfo &STI) {
   unsigned Opcode = Inst.getOpcode();
   auto Info = getMemInstInfo(Opcode);
 
@@ -578,15 +593,16 @@ void AArch64MCLFIRewriter::rewriteLoadStore(const MCInst &Inst, MCStreamer &Out,
   if (rewriteLoadStoreRoW(Inst, Out, STI))
     return;
 
-  rewriteLoadStoreBasic(Inst, Out, STI);
+  rewriteLoadStoreBase(Inst, Out, STI);
 }
 
 // modify sp
 // ->
 // modify x26
 // add sp, x27, w26, uxtw
-void AArch64MCLFIRewriter::rewriteStackModification(
-    const MCInst &Inst, MCStreamer &Out, const MCSubtargetInfo &STI) {
+void AArch64MCLFIRewriter::rewriteSPModification(const MCInst &Inst,
+                                                 MCStreamer &Out,
+                                                 const MCSubtargetInfo &STI) {
   // Route through rewriteLRModification or rewriteLoadStore for memory
   // accesses. Those helpers automatically handle dangerous stack modifications
   // that can happen via register post-index.
@@ -667,15 +683,15 @@ void AArch64MCLFIRewriter::doRewriteInst(const MCInst &Inst, MCStreamer &Out,
   }
 
   // Register modifications that require sandboxing.
-  if (mayModifyStack(Inst))
-    return rewriteStackModification(Inst, Out, STI);
+  if (mayModifySP(Inst))
+    return rewriteSPModification(Inst, Out, STI);
 
   // Link register modification.
   if (explicitlyModifiesRegister(Inst, AArch64::LR))
     return rewriteLRModification(Inst, Out, STI);
 
   // Memory access.
-  if (!isNotMemAccess(Inst) &&
+  if (!isFakeMemAccess(Inst) &&
       (mayLoad(Inst) || mayStore(Inst) || mayPrefetch(Inst)))
     return rewriteLoadStore(Inst, Out, STI);
 
@@ -861,7 +877,7 @@ bool AArch64MCLFIRewriter::rewriteInst(const MCInst &Inst, MCStreamer &Out,
 //
 // Returns information about how to find the base register and offset operands
 // in a memory instruction, and whether it uses pre/post-indexed addressing.
-// Used by rewriteLoadStoreBasic as a fallback when RoW conversion isn't
+// Used by rewriteLoadStoreBase as a fallback when RoW conversion isn't
 // possible.
 static std::optional<MemInstInfo> getMemInstInfo(unsigned Op) {
   switch (Op) {

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
@@ -18,6 +18,8 @@
 
 #include "llvm/ADT/Twine.h"
 #include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCInstrDesc.h"
+#include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 
@@ -63,6 +65,97 @@ static bool isPrivilegedTPAccess(const MCInst &Inst) {
   if (Inst.getOpcode() == AArch64::MSR)
     return isPrivilegedTP(Inst.getOperand(0).getImm());
   return false;
+}
+
+// Instructions that have mayLoad/mayStore set in TableGen but don't actually
+// perform memory accesses.
+static bool isNotMemAccess(const MCInst &Inst) {
+  switch (Inst.getOpcode()) {
+  case AArch64::DMB:
+  case AArch64::DSB:
+  case AArch64::ISB:
+  case AArch64::HINT:
+    return true;
+  default:
+    return false;
+  }
+}
+
+static bool mayPrefetch(const MCInst &Inst) {
+  switch (Inst.getOpcode()) {
+  case AArch64::PRFMl:
+  case AArch64::PRFMroW:
+  case AArch64::PRFMroX:
+  case AArch64::PRFMui:
+  case AArch64::PRFUMi:
+    return true;
+  default:
+    return false;
+  }
+}
+
+// User-mode DC/IC instructions that take a virtual address operand. Encoded as
+// SYSxt with op1=3, Cn=7, op2=1 where the Cm field selects the operation.
+static bool isVASysOp(const MCInst &Inst) {
+  if (Inst.getOpcode() != AArch64::SYSxt)
+    return false;
+  if (Inst.getOperand(0).getImm() != 3 || Inst.getOperand(1).getImm() != 7 ||
+      Inst.getOperand(3).getImm() != 1)
+    return false;
+  switch (Inst.getOperand(2).getImm()) {
+  case 4:  // DC ZVA
+  case 5:  // IC IVAU
+  case 10: // DC CVAC
+  case 11: // DC CVAU
+  case 12: // DC CVAP
+  case 13: // DC CVADP
+  case 14: // DC CIVAC
+    return true;
+  default:
+    return false;
+  }
+}
+
+static MCInst replaceRegAt(const MCInst &Inst, unsigned Idx,
+                           MCRegister NewReg) {
+  MCInst New;
+  New.setOpcode(Inst.getOpcode());
+  New.setLoc(Inst.getLoc());
+  for (unsigned I = 0, E = Inst.getNumOperands(); I != E; ++I) {
+    if (I == Idx)
+      New.addOperand(MCOperand::createReg(NewReg));
+    else
+      New.addOperand(Inst.getOperand(I));
+  }
+  return New;
+}
+
+// Memory instruction information for the basic load/store rewriting path.
+// Provides operand indices for the base register and offset, and whether
+// the instruction uses pre/post-indexed addressing.
+struct MemInstInfo {
+  int BaseRegIdx;
+  int OffsetIdx; // -1 if no offset operand.
+  bool IsPrePost;
+  bool IsLiteral;
+};
+
+// Returns memory instruction info for a given opcode, or std::nullopt if
+// the opcode is not a recognized memory instruction.
+static std::optional<MemInstInfo> getMemInstInfo(unsigned Op);
+
+static unsigned convertUiToRoW(unsigned Op);
+static unsigned convertPreToRoW(unsigned Op);
+static unsigned convertPostToRoW(unsigned Op);
+static unsigned convertRoXToRoW(unsigned Op, unsigned &Shift);
+static bool getRoWShift(unsigned Op, unsigned &Shift);
+static unsigned getPrePostScale(unsigned Op);
+static unsigned convertPrePostToBase(unsigned Op, bool &IsPre,
+                                     bool &IsNoOffset);
+static int getSIMDNaturalOffset(unsigned Op);
+
+bool AArch64MCLFIRewriter::mayModifyStack(const MCInst &Inst) const {
+  return mayModifyRegister(Inst, AArch64::SP);
 }
 
 MCRegister AArch64MCLFIRewriter::mayModifyReserved(const MCInst &Inst) const {
@@ -114,6 +207,75 @@ void AArch64MCLFIRewriter::emitMov(MCRegister Dest, MCRegister Src,
   emitInst(Inst, Out, STI);
 }
 
+void AArch64MCLFIRewriter::emitAddImm(MCRegister Dest, MCRegister Src,
+                                      int64_t Imm, MCStreamer &Out,
+                                      const MCSubtargetInfo &STI) {
+  assert(std::abs(Imm) <= 4095);
+  MCInst Inst;
+  if (Imm >= 0) {
+    Inst.setOpcode(AArch64::ADDXri);
+    Inst.addOperand(MCOperand::createReg(Dest));
+    Inst.addOperand(MCOperand::createReg(Src));
+    Inst.addOperand(MCOperand::createImm(Imm));
+    Inst.addOperand(MCOperand::createImm(0)); // shift
+  } else {
+    Inst.setOpcode(AArch64::SUBXri);
+    Inst.addOperand(MCOperand::createReg(Dest));
+    Inst.addOperand(MCOperand::createReg(Src));
+    Inst.addOperand(MCOperand::createImm(-Imm));
+    Inst.addOperand(MCOperand::createImm(0)); // shift
+  }
+  emitInst(Inst, Out, STI);
+}
+
+void AArch64MCLFIRewriter::emitAddReg(MCRegister Dest, MCRegister Src1,
+                                      MCRegister Src2, unsigned Shift,
+                                      MCStreamer &Out,
+                                      const MCSubtargetInfo &STI) {
+  // add Dest, Src1, Src2, lsl #Shift
+  MCInst Inst;
+  Inst.setOpcode(AArch64::ADDXrs);
+  Inst.addOperand(MCOperand::createReg(Dest));
+  Inst.addOperand(MCOperand::createReg(Src1));
+  Inst.addOperand(MCOperand::createReg(Src2));
+  Inst.addOperand(
+      MCOperand::createImm(AArch64_AM::getShifterImm(AArch64_AM::LSL, Shift)));
+  emitInst(Inst, Out, STI);
+}
+
+void AArch64MCLFIRewriter::emitAddRegExtend(MCRegister Dest, MCRegister Src1,
+                                            MCRegister Src2,
+                                            AArch64_AM::ShiftExtendType ExtType,
+                                            unsigned Shift, MCStreamer &Out,
+                                            const MCSubtargetInfo &STI) {
+  // add Dest, Src1, Src2, ExtType #Shift
+  MCInst Inst;
+  if (ExtType == AArch64_AM::SXTX || ExtType == AArch64_AM::UXTX)
+    Inst.setOpcode(AArch64::ADDXrx64);
+  else
+    Inst.setOpcode(AArch64::ADDXrx);
+  Inst.addOperand(MCOperand::createReg(Dest));
+  Inst.addOperand(MCOperand::createReg(Src1));
+  Inst.addOperand(MCOperand::createReg(Src2));
+  Inst.addOperand(
+      MCOperand::createImm(AArch64_AM::getArithExtendImm(ExtType, Shift)));
+  emitInst(Inst, Out, STI);
+}
+
+void AArch64MCLFIRewriter::emitMemRoW(unsigned Opcode, const MCOperand &DataOp,
+                                      MCRegister BaseReg, MCStreamer &Out,
+                                      const MCSubtargetInfo &STI) {
+  // Op DataOp, [LFIBaseReg, W(BaseReg), uxtw]
+  MCInst Inst;
+  Inst.setOpcode(Opcode);
+  Inst.addOperand(DataOp);
+  Inst.addOperand(MCOperand::createReg(LFIBaseReg));
+  Inst.addOperand(MCOperand::createReg(getWRegFromXReg(BaseReg)));
+  Inst.addOperand(MCOperand::createImm(0)); // S bit = 0 (UXTW).
+  Inst.addOperand(MCOperand::createImm(0)); // Shift amount = 0 (unscaled).
+  emitInst(Inst, Out, STI);
+}
+
 // {br,blr} xN
 // ->
 // add x28, x27, wN, uxtw
@@ -154,7 +316,11 @@ void AArch64MCLFIRewriter::rewriteReturn(const MCInst &Inst, MCStreamer &Out,
 void AArch64MCLFIRewriter::rewriteLRModification(const MCInst &Inst,
                                                  MCStreamer &Out,
                                                  const MCSubtargetInfo &STI) {
-  emitInst(Inst, Out, STI);
+  if (!isNotMemAccess(Inst) &&
+      (mayLoad(Inst) || mayStore(Inst) || mayPrefetch(Inst)))
+    rewriteLoadStore(Inst, Out, STI);
+  else
+    emitInst(Inst, Out, STI);
   emitAddMask(AArch64::LR, AArch64::LR, Out, STI);
 }
 
@@ -214,6 +380,254 @@ void AArch64MCLFIRewriter::rewriteTPWrite(const MCInst &Inst, MCStreamer &Out,
   emitInst(Store, Out, STI);
 }
 
+bool AArch64MCLFIRewriter::rewriteLoadStoreRoW(const MCInst &Inst,
+                                               MCStreamer &Out,
+                                               const MCSubtargetInfo &STI) {
+  unsigned Op = Inst.getOpcode();
+  unsigned MemOp;
+
+  // Case 1: Indexed load/store with zero immediate offset.
+  // ldr xN, [xM, #0] -> ldr xN, [x27, wM, uxtw]
+  if ((MemOp = convertUiToRoW(Op)) != AArch64::INSTRUCTION_LIST_END) {
+    MCRegister BaseReg = Inst.getOperand(1).getReg();
+    if (BaseReg == AArch64::SP)
+      return false;
+    const MCOperand &OffsetOp = Inst.getOperand(2);
+    if (OffsetOp.isImm() && OffsetOp.getImm() == 0) {
+      emitMemRoW(MemOp, Inst.getOperand(0), BaseReg, Out, STI);
+      return true;
+    }
+    return false;
+  }
+
+  // Case 2: Pre-index load/store.
+  // ldr xN, [xM, #imm]! -> add xM, xM, #imm; ldr xN, [x27, wM, uxtw]
+  if ((MemOp = convertPreToRoW(Op)) != AArch64::INSTRUCTION_LIST_END) {
+    MCRegister BaseReg = Inst.getOperand(2).getReg();
+    if (BaseReg == AArch64::SP)
+      return false;
+    int64_t Imm = Inst.getOperand(3).getImm();
+    emitAddImm(BaseReg, BaseReg, Imm, Out, STI);
+    emitMemRoW(MemOp, Inst.getOperand(1), BaseReg, Out, STI);
+    return true;
+  }
+
+  // Case 3: Post-index load/store.
+  // ldr xN, [xM], #imm -> ldr xN, [x27, wM, uxtw]; add xM, xM, #imm
+  if ((MemOp = convertPostToRoW(Op)) != AArch64::INSTRUCTION_LIST_END) {
+    MCRegister BaseReg = Inst.getOperand(2).getReg();
+    if (BaseReg == AArch64::SP)
+      return false;
+    int64_t Imm = Inst.getOperand(3).getImm();
+    emitMemRoW(MemOp, Inst.getOperand(1), BaseReg, Out, STI);
+    emitAddImm(BaseReg, BaseReg, Imm, Out, STI);
+    return true;
+  }
+
+  // Case 4: Register-offset-X load/store.
+  // ldr xN, [xM1, xM2] -> add x26, xM1, xM2; ldr xN, [x27, w26, uxtw]
+  unsigned Shift;
+  if ((MemOp = convertRoXToRoW(Op, Shift)) != AArch64::INSTRUCTION_LIST_END) {
+    MCRegister Reg1 = Inst.getOperand(1).getReg();
+    MCRegister Reg2 = Inst.getOperand(2).getReg();
+    int64_t Extend = Inst.getOperand(3).getImm();
+    int64_t IsShift = Inst.getOperand(4).getImm();
+
+    if (!IsShift)
+      Shift = 0;
+
+    if (Extend)
+      emitAddRegExtend(LFIScratchReg, Reg1, Reg2, AArch64_AM::SXTX, Shift, Out,
+                       STI);
+    else
+      emitAddReg(LFIScratchReg, Reg1, Reg2, Shift, Out, STI);
+    emitMemRoW(MemOp, Inst.getOperand(0), LFIScratchReg, Out, STI);
+    return true;
+  }
+
+  // Case 5: Register-offset-W load/store.
+  // ldr xN, [xM1, wM2, uxtw] -> add x26, xM1, wM2, uxtw;
+  //                             ldr xN, [x27, w26, uxtw]
+  if (getRoWShift(Op, Shift)) {
+    MCRegister Reg1 = Inst.getOperand(1).getReg();
+    MCRegister Reg2 = Inst.getOperand(2).getReg();
+    int64_t S = Inst.getOperand(3).getImm();
+    int64_t IsShift = Inst.getOperand(4).getImm();
+
+    if (!IsShift)
+      Shift = 0;
+
+    if (S)
+      emitAddRegExtend(LFIScratchReg, Reg1, Reg2, AArch64_AM::SXTW, Shift, Out,
+                       STI);
+    else
+      emitAddRegExtend(LFIScratchReg, Reg1, Reg2, AArch64_AM::UXTW, Shift, Out,
+                       STI);
+    emitMemRoW(Op, Inst.getOperand(0), LFIScratchReg, Out, STI);
+    return true;
+  }
+
+  return false;
+}
+
+void AArch64MCLFIRewriter::rewriteLoadStoreBasic(const MCInst &Inst,
+                                                 MCStreamer &Out,
+                                                 const MCSubtargetInfo &STI) {
+  unsigned Opcode = Inst.getOpcode();
+  auto Info = getMemInstInfo(Opcode);
+
+  if (!Info)
+    return error(Inst, "unknown addressing mode for memory instruction in LFI");
+
+  if (Info->IsLiteral)
+    return error(Inst, "PC-relative literal loads are not supported in LFI");
+
+  MCRegister BaseReg = Inst.getOperand(Info->BaseRegIdx).getReg();
+
+  // Stack accesses don't need address sandboxing, except when sp is modified
+  // with a register post-index operand.
+  bool BaseIsSP = BaseReg == AArch64::SP;
+  if (BaseIsSP) {
+    if (Info->OffsetIdx < 0 || !Inst.getOperand(Info->OffsetIdx).isReg())
+      return emitInst(Inst, Out, STI);
+    MCRegister OffReg = Inst.getOperand(Info->OffsetIdx).getReg();
+    if (OffReg == AArch64::XZR || OffReg == AArch64::WZR)
+      return emitInst(Inst, Out, STI);
+  }
+
+  // Guard the base register, unless it is SP.
+  MCRegister AccessBase = BaseIsSP ? AArch64::SP : LFIAddrReg;
+  if (!BaseIsSP)
+    emitAddMask(LFIAddrReg, BaseReg, Out, STI);
+
+  if (Info->IsPrePost) {
+    bool IsPre = false;
+    bool IsNoOffset = false;
+    unsigned BaseOpcode = convertPrePostToBase(Opcode, IsPre, IsNoOffset);
+
+    if (BaseOpcode != AArch64::INSTRUCTION_LIST_END) {
+      // Demote pre/post-index to base indexed form.
+      MCInst NewInst;
+      NewInst.setOpcode(BaseOpcode);
+      NewInst.setLoc(Inst.getLoc());
+
+      // Skip writeback operand (operand 0) and copy data operands up to base.
+      for (int I = 1; I < Info->BaseRegIdx; ++I)
+        NewInst.addOperand(Inst.getOperand(I));
+
+      // Add the access base register (LFIAddrReg or SP).
+      NewInst.addOperand(MCOperand::createReg(AccessBase));
+
+      // For pre-index, include the offset; for post-index, use zero.
+      if (IsPre && Info->OffsetIdx >= 0)
+        NewInst.addOperand(Inst.getOperand(Info->OffsetIdx));
+      else if (!IsNoOffset)
+        NewInst.addOperand(MCOperand::createImm(0));
+
+      emitInst(NewInst, Out, STI);
+
+      // Update the base register with the offset. If the base is SP, a
+      // register offset must be sandboxed (the result is otherwise
+      // unbounded), and ADDXrs cannot take SP, so the extended-register form
+      // via the scratch register is used.
+      if (Info->OffsetIdx >= 0) {
+        const MCOperand &OffsetOp = Inst.getOperand(Info->OffsetIdx);
+        if (OffsetOp.isImm()) {
+          int64_t Scale = getPrePostScale(Opcode);
+          int64_t Offset = OffsetOp.getImm() * Scale;
+          emitAddImm(BaseReg, BaseReg, Offset, Out, STI);
+        } else if (OffsetOp.isReg()) {
+          // SIMD post-index uses a register offset (XZR for natural offset).
+          MCRegister OffReg = OffsetOp.getReg();
+          if (OffReg == AArch64::XZR) {
+            int NaturalOffset = getSIMDNaturalOffset(Opcode);
+            if (NaturalOffset > 0)
+              emitAddImm(BaseReg, BaseReg, NaturalOffset, Out, STI);
+          } else if (OffReg != AArch64::WZR) {
+            if (BaseIsSP) {
+              emitAddRegExtend(LFIScratchReg, AArch64::SP, OffReg,
+                               AArch64_AM::UXTX, 0, Out, STI);
+              emitAddMask(AArch64::SP, LFIScratchReg, Out, STI);
+            } else {
+              emitAddReg(BaseReg, BaseReg, OffReg, 0, Out, STI);
+            }
+          }
+        }
+      }
+    } else {
+      error(Inst, "unhandled pre/post-index instruction in LFI rewriter");
+    }
+  } else {
+    // Non-pre/post instruction: replace the base register operand.
+    MCInst NewInst = replaceRegAt(Inst, Info->BaseRegIdx, LFIAddrReg);
+    emitInst(NewInst, Out, STI);
+  }
+}
+
+void AArch64MCLFIRewriter::rewriteLoadStore(const MCInst &Inst, MCStreamer &Out,
+                                            const MCSubtargetInfo &STI) {
+  bool IsStore = mayStore(Inst);
+  bool IsLoad = mayLoad(Inst) || mayPrefetch(Inst);
+
+  bool SkipLoads = STI.hasFeature(AArch64::FeatureNoLFILoads);
+  bool SkipStores = STI.hasFeature(AArch64::FeatureNoLFIStores);
+
+  if ((!IsLoad || SkipLoads) && (!IsStore || SkipStores))
+    return emitInst(Inst, Out, STI);
+
+  if (rewriteLoadStoreRoW(Inst, Out, STI))
+    return;
+
+  rewriteLoadStoreBasic(Inst, Out, STI);
+}
+
+// modify sp
+// ->
+// modify x26
+// add sp, x27, w26, uxtw
+void AArch64MCLFIRewriter::rewriteStackModification(
+    const MCInst &Inst, MCStreamer &Out, const MCSubtargetInfo &STI) {
+  // Route through rewriteLRModification or rewriteLoadStore for memory
+  // accesses. Those helpers automatically handle dangerous stack modifications
+  // that can happen via register post-index.
+  if (mayLoad(Inst) || mayStore(Inst)) {
+    if (mayModifyRegister(Inst, AArch64::LR))
+      return rewriteLRModification(Inst, Out, STI);
+    return rewriteLoadStore(Inst, Out, STI);
+  }
+
+  // No stack sandboxing if sandboxing is disabled for both loads and stores.
+  bool SkipLoads = STI.hasFeature(AArch64::FeatureNoLFILoads);
+  bool SkipStores = STI.hasFeature(AArch64::FeatureNoLFIStores);
+  if (SkipLoads && SkipStores)
+    return emitInst(Inst, Out, STI);
+
+  // Redirect SP modification destination to scratch, then sandbox.
+  MCInst ModInst = replaceRegAt(Inst, 0, LFIScratchReg);
+  emitInst(ModInst, Out, STI);
+  emitAddMask(AArch64::SP, LFIScratchReg, Out, STI);
+}
+
+// {dc,ic} <op>, xN
+// ->
+// add x28, x27, wN, uxtw
+// {dc,ic} <op>, x28
+void AArch64MCLFIRewriter::rewriteVASysOp(const MCInst &Inst, MCStreamer &Out,
+                                          const MCSubtargetInfo &STI) {
+  MCRegister AddrReg = Inst.getOperand(4).getReg();
+
+  emitAddMask(LFIAddrReg, AddrReg, Out, STI);
+
+  MCInst NewInst;
+  NewInst.setOpcode(AArch64::SYSxt);
+  NewInst.addOperand(Inst.getOperand(0));
+  NewInst.addOperand(Inst.getOperand(1));
+  NewInst.addOperand(Inst.getOperand(2));
+  NewInst.addOperand(Inst.getOperand(3));
+  NewInst.addOperand(MCOperand::createReg(LFIAddrReg));
+  emitInst(NewInst, Out, STI);
+}
+
 // NOTE: when adding new rewrites, the size estimates in
 // AArch64InstrInfo::getLFIInstSizeInBytes must be updated to match.
 void AArch64MCLFIRewriter::doRewriteInst(const MCInst &Inst, MCStreamer &Out,
@@ -240,6 +654,9 @@ void AArch64MCLFIRewriter::doRewriteInst(const MCInst &Inst, MCStreamer &Out,
     return;
   }
 
+  if (isVASysOp(Inst))
+    return rewriteVASysOp(Inst, Out, STI);
+
   // Control flow.
   switch (Inst.getOpcode()) {
   case AArch64::RET:
@@ -249,11 +666,34 @@ void AArch64MCLFIRewriter::doRewriteInst(const MCInst &Inst, MCStreamer &Out,
     return rewriteIndirectBranch(Inst, Out, STI);
   }
 
+  // Register modifications that require sandboxing.
+  if (mayModifyStack(Inst))
+    return rewriteStackModification(Inst, Out, STI);
+
   // Link register modification.
   if (explicitlyModifiesRegister(Inst, AArch64::LR))
     return rewriteLRModification(Inst, Out, STI);
 
+  // Memory access.
+  if (!isNotMemAccess(Inst) &&
+      (mayLoad(Inst) || mayStore(Inst) || mayPrefetch(Inst)))
+    return rewriteLoadStore(Inst, Out, STI);
+
   emitInst(Inst, Out, STI);
+}
+
+// This function is made available to the size estimator so that it can
+// classify Pre/Post-index instructions.
+bool llvm::isLFIPrePostMemAccess(unsigned Opcode) {
+  if (convertPreToRoW(Opcode) != AArch64::INSTRUCTION_LIST_END)
+    return true;
+  if (convertPostToRoW(Opcode) != AArch64::INSTRUCTION_LIST_END)
+    return true;
+  bool IsPre, IsNoOffset;
+  if (convertPrePostToBase(Opcode, IsPre, IsNoOffset) !=
+      AArch64::INSTRUCTION_LIST_END)
+    return true;
+  return false;
 }
 
 bool AArch64MCLFIRewriter::rewriteInst(const MCInst &Inst, MCStreamer &Out,
@@ -268,4 +708,525 @@ bool AArch64MCLFIRewriter::rewriteInst(const MCInst &Inst, MCStreamer &Out,
 
   Guard = false;
   return true;
+}
+
+// Opcode X-macro Tables
+//
+// These macros define groups of related opcodes and are used to generate
+// multiple switch tables without repetition. Each macro takes a callback X and
+// invokes X(NAME, VALUE) for each entry.
+
+// Scalar memory ops that have ui, pre, post, roX, and roW variants.
+// PRFM is excluded because it has no pre/post forms.
+// The second column is the log2 element size (shift for scaled addressing).
+#define SCALAR_MEM_OPS(X)                                                      \
+  X(LDRBB, 0)                                                                  \
+  X(LDRB, 0)                                                                   \
+  X(LDRSBW, 0)                                                                 \
+  X(LDRSBX, 0)                                                                 \
+  X(STRBB, 0)                                                                  \
+  X(STRB, 0)                                                                   \
+  X(LDRHH, 1)                                                                  \
+  X(LDRH, 1)                                                                   \
+  X(LDRSHW, 1)                                                                 \
+  X(LDRSHX, 1)                                                                 \
+  X(STRHH, 1)                                                                  \
+  X(STRH, 1)                                                                   \
+  X(LDRSW, 2)                                                                  \
+  X(LDRS, 2)                                                                   \
+  X(LDRW, 2)                                                                   \
+  X(STRS, 2)                                                                   \
+  X(STRW, 2)                                                                   \
+  X(LDRD, 3)                                                                   \
+  X(LDRX, 3)                                                                   \
+  X(STRD, 3)                                                                   \
+  X(STRX, 3)                                                                   \
+  X(LDRQ, 4)                                                                   \
+  X(STRQ, 4)
+
+// LDP/STP pair ops. The second column is the scale factor for pre/post
+// immediates.
+#define PAIR_OPS(X)                                                            \
+  X(LDPD, 8)                                                                   \
+  X(LDPQ, 16)                                                                  \
+  X(LDPSW, 4)                                                                  \
+  X(LDPS, 4)                                                                   \
+  X(LDPW, 4)                                                                   \
+  X(LDPX, 8)                                                                   \
+  X(STPD, 8)                                                                   \
+  X(STPQ, 16)                                                                  \
+  X(STPS, 4)                                                                   \
+  X(STPW, 4)                                                                   \
+  X(STPX, 8)
+
+// SIMD post-index ops, split into three groups by operand layout.
+// The second column is the natural byte offset for post-index.
+
+// Lane stores: Vt, idx, [Rn] (base=2) / wback, Vt, idx, [Rn], Xm (base=3).
+
+// clang-format off
+#define SIMD_LANE_STORE_OPS(X)                                                 \
+  X(ST1i8, 1) X(ST1i16, 2) X(ST1i32,  4) X(ST1i64,  8)                         \
+  X(ST2i8, 2) X(ST2i16, 4) X(ST2i32,  8) X(ST2i64, 16)                         \
+  X(ST3i8, 3) X(ST3i16, 6) X(ST3i32, 12) X(ST3i64, 24)                         \
+  X(ST4i8, 4) X(ST4i16, 8) X(ST4i32, 16) X(ST4i64, 32)
+
+// Lane loads: Vt(out), Vt(tied), idx, [Rn] (base=3) /
+//             wback, Vt(out), Vt(tied), idx, [Rn], Xm (base=4).
+#define SIMD_LANE_LOAD_OPS(X)                                                  \
+  X(LD1i8, 1) X(LD1i16, 2) X(LD1i32,  4) X(LD1i64,  8)                         \
+  X(LD2i8, 2) X(LD2i16, 4) X(LD2i32,  8) X(LD2i64, 16)                         \
+  X(LD3i8, 3) X(LD3i16, 6) X(LD3i32, 12) X(LD3i64, 24)                         \
+  X(LD4i8, 4) X(LD4i16, 8) X(LD4i32, 16) X(LD4i64, 32)
+
+// Multiple structure and replicate: Vt, [Rn] (base=1) /
+//                                   wback, Vt, [Rn], Xm (base=2).
+// Each line pairs the LD and ST variants (replicates are LD-only).
+#define SIMD_MULTI_OPS(X)                                                      \
+  /* Replicate loads (LD only). */                                             \
+  X(LD1Rv8b,  1) X(LD1Rv16b,  1) X(LD1Rv4h,  2) X(LD1Rv8h,  2)                 \
+  X(LD1Rv2s,  4) X(LD1Rv4s,   4) X(LD1Rv1d,  8) X(LD1Rv2d,  8)                 \
+  X(LD2Rv8b,  2) X(LD2Rv16b,  2) X(LD2Rv4h,  4) X(LD2Rv8h,  4)                 \
+  X(LD2Rv2s,  8) X(LD2Rv4s,   8) X(LD2Rv1d, 16) X(LD2Rv2d, 16)                 \
+  X(LD3Rv8b,  3) X(LD3Rv16b,  3) X(LD3Rv4h,  6) X(LD3Rv8h,  6)                 \
+  X(LD3Rv2s, 12) X(LD3Rv4s,  12) X(LD3Rv1d, 24) X(LD3Rv2d, 24)                 \
+  X(LD4Rv8b,  4) X(LD4Rv16b,  4) X(LD4Rv4h,  8) X(LD4Rv8h,  8)                 \
+  X(LD4Rv2s, 16) X(LD4Rv4s,  16) X(LD4Rv1d, 32) X(LD4Rv2d, 32)                 \
+  /* LD1/ST1 One register. */                                                  \
+  X(LD1Onev8b, 8) X(LD1Onev16b, 16)                                            \
+  X(LD1Onev4h, 8) X(LD1Onev8h,  16)                                            \
+  X(LD1Onev2s, 8) X(LD1Onev4s,  16)                                            \
+  X(LD1Onev1d, 8) X(LD1Onev2d,  16)                                            \
+  X(ST1Onev8b, 8) X(ST1Onev16b, 16)                                            \
+  X(ST1Onev4h, 8) X(ST1Onev8h,  16)                                            \
+  X(ST1Onev2s, 8) X(ST1Onev4s,  16)                                            \
+  X(ST1Onev1d, 8) X(ST1Onev2d,  16)                                            \
+  /* LD1/ST1 Two registers. */                                                 \
+  X(LD1Twov8b, 16) X(LD1Twov16b, 32)                                           \
+  X(LD1Twov4h, 16) X(LD1Twov8h,  32)                                           \
+  X(LD1Twov2s, 16) X(LD1Twov4s,  32)                                           \
+  X(LD1Twov1d, 16) X(LD1Twov2d,  32)                                           \
+  X(ST1Twov8b, 16) X(ST1Twov16b, 32)                                           \
+  X(ST1Twov4h, 16) X(ST1Twov8h,  32)                                           \
+  X(ST1Twov2s, 16) X(ST1Twov4s,  32)                                           \
+  X(ST1Twov1d, 16) X(ST1Twov2d,  32)                                           \
+  /* LD1/ST1 Three registers. */                                               \
+  X(LD1Threev8b, 24) X(LD1Threev16b, 48)                                       \
+  X(LD1Threev4h, 24) X(LD1Threev8h,  48)                                       \
+  X(LD1Threev2s, 24) X(LD1Threev4s,  48)                                       \
+  X(LD1Threev1d, 24) X(LD1Threev2d,  48)                                       \
+  X(ST1Threev8b, 24) X(ST1Threev16b, 48)                                       \
+  X(ST1Threev4h, 24) X(ST1Threev8h,  48)                                       \
+  X(ST1Threev2s, 24) X(ST1Threev4s,  48)                                       \
+  X(ST1Threev1d, 24) X(ST1Threev2d,  48)                                       \
+  /* LD1/ST1 Four registers. */                                                \
+  X(LD1Fourv8b, 32) X(LD1Fourv16b, 64)                                         \
+  X(LD1Fourv4h, 32) X(LD1Fourv8h,  64)                                         \
+  X(LD1Fourv2s, 32) X(LD1Fourv4s,  64)                                         \
+  X(LD1Fourv1d, 32) X(LD1Fourv2d,  64)                                         \
+  X(ST1Fourv8b, 32) X(ST1Fourv16b, 64)                                         \
+  X(ST1Fourv4h, 32) X(ST1Fourv8h,  64)                                         \
+  X(ST1Fourv2s, 32) X(ST1Fourv4s,  64)                                         \
+  X(ST1Fourv1d, 32) X(ST1Fourv2d,  64)                                         \
+  /* LD2/ST2 Two registers. */                                                 \
+  X(LD2Twov8b, 16) X(LD2Twov16b, 32)                                           \
+  X(LD2Twov4h, 16) X(LD2Twov8h,  32)                                           \
+  X(LD2Twov2s, 16) X(LD2Twov4s,  32) X(LD2Twov2d, 32)                          \
+  X(ST2Twov8b, 16) X(ST2Twov16b, 32)                                           \
+  X(ST2Twov4h, 16) X(ST2Twov8h,  32)                                           \
+  X(ST2Twov2s, 16) X(ST2Twov4s,  32) X(ST2Twov2d, 32)                          \
+  /* LD3/ST3 Three registers. */                                               \
+  X(LD3Threev8b, 24) X(LD3Threev16b, 48)                                       \
+  X(LD3Threev4h, 24) X(LD3Threev8h,  48)                                       \
+  X(LD3Threev2s, 24) X(LD3Threev4s,  48) X(LD3Threev2d, 48)                    \
+  X(ST3Threev8b, 24) X(ST3Threev16b, 48)                                       \
+  X(ST3Threev4h, 24) X(ST3Threev8h,  48)                                       \
+  X(ST3Threev2s, 24) X(ST3Threev4s,  48) X(ST3Threev2d, 48)                    \
+  /* LD4/ST4 Four registers. */                                                \
+  X(LD4Fourv8b, 32) X(LD4Fourv16b, 64)                                         \
+  X(LD4Fourv4h, 32) X(LD4Fourv8h,  64)                                         \
+  X(LD4Fourv2s, 32) X(LD4Fourv4s,  64) X(LD4Fourv2d,  64)                      \
+  X(ST4Fourv8b, 32) X(ST4Fourv16b, 64)                                         \
+  X(ST4Fourv4h, 32) X(ST4Fourv8h,  64)                                         \
+  X(ST4Fourv2s, 32) X(ST4Fourv4s,  64) X(ST4Fourv2d,  64)
+// clang-format on
+
+// Union of all SIMD post-index ops.
+#define SIMD_POST_OPS(X)                                                       \
+  SIMD_LANE_STORE_OPS(X)                                                       \
+  SIMD_LANE_LOAD_OPS(X)                                                        \
+  SIMD_MULTI_OPS(X)
+
+// Memory Instruction Info Table
+//
+// Returns information about how to find the base register and offset operands
+// in a memory instruction, and whether it uses pre/post-indexed addressing.
+// Used by rewriteLoadStoreBasic as a fallback when RoW conversion isn't
+// possible.
+static std::optional<MemInstInfo> getMemInstInfo(unsigned Op) {
+  switch (Op) {
+  default:
+    return std::nullopt;
+
+  // PC-relative literal loads: Rt, label
+  case AArch64::LDRWl:
+  case AArch64::LDRXl:
+  case AArch64::LDRSWl:
+  case AArch64::LDRSl:
+  case AArch64::LDRDl:
+  case AArch64::LDRQl:
+  case AArch64::PRFMl:
+    return MemInstInfo{0, -1, false, true};
+
+    // Scalar indexed/unscaled/register-offset: Rt, [Rn, ...]
+#define X(NAME, S)                                                             \
+  case AArch64::NAME##ui:                                                      \
+  case AArch64::NAME##roW:                                                     \
+  case AArch64::NAME##roX:
+    SCALAR_MEM_OPS(X)
+#undef X
+  case AArch64::PRFMui:
+  case AArch64::PRFMroW:
+  case AArch64::PRFMroX:
+  // Unscaled variants.
+  case AArch64::LDURBBi:
+  case AArch64::LDURBi:
+  case AArch64::LDURDi:
+  case AArch64::LDURHHi:
+  case AArch64::LDURHi:
+  case AArch64::LDURQi:
+  case AArch64::LDURSBWi:
+  case AArch64::LDURSBXi:
+  case AArch64::LDURSHWi:
+  case AArch64::LDURSHXi:
+  case AArch64::LDURSWi:
+  case AArch64::LDURSi:
+  case AArch64::LDURWi:
+  case AArch64::LDURXi:
+  case AArch64::STURBBi:
+  case AArch64::STURBi:
+  case AArch64::STURDi:
+  case AArch64::STURHHi:
+  case AArch64::STURHi:
+  case AArch64::STURQi:
+  case AArch64::STURSi:
+  case AArch64::STURWi:
+  case AArch64::STURXi:
+  case AArch64::PRFUMi:
+    return MemInstInfo{1, 2, false, false};
+
+    // Scalar pre/post-index: wback, Rt, [Rn], #imm
+#define X(NAME, S)                                                             \
+  case AArch64::NAME##pre:                                                     \
+  case AArch64::NAME##post:
+    SCALAR_MEM_OPS(X)
+#undef X
+    return MemInstInfo{2, 3, true, false};
+
+  // Exclusive/acquire loads: Rt, [Rn]
+  case AArch64::LDXRB:
+  case AArch64::LDXRH:
+  case AArch64::LDXRW:
+  case AArch64::LDXRX:
+  case AArch64::LDAXRB:
+  case AArch64::LDAXRH:
+  case AArch64::LDAXRW:
+  case AArch64::LDAXRX:
+  case AArch64::LDARB:
+  case AArch64::LDARH:
+  case AArch64::LDARW:
+  case AArch64::LDARX:
+  case AArch64::LDLARB:
+  case AArch64::LDLARH:
+  case AArch64::LDLARW:
+  case AArch64::LDLARX:
+  // RCPC loads: Rt, [Rn]
+  case AArch64::LDAPRB:
+  case AArch64::LDAPRH:
+  case AArch64::LDAPRW:
+  case AArch64::LDAPRX:
+  // Store-release: Rt, [Rn]
+  case AArch64::STLRB:
+  case AArch64::STLRH:
+  case AArch64::STLRW:
+  case AArch64::STLRX:
+  case AArch64::STLLRB:
+  case AArch64::STLLRH:
+  case AArch64::STLLRW:
+  case AArch64::STLLRX:
+    // SIMD multiple/replicate (base form): Vt, [Rn]
+#define X(NAME, OFF) case AArch64::NAME:
+    SIMD_MULTI_OPS(X)
+#undef X
+    return MemInstInfo{1, -1, false, false};
+
+  // Exclusive stores: Ws, Rt, [Rn]
+  case AArch64::STXRB:
+  case AArch64::STXRH:
+  case AArch64::STXRW:
+  case AArch64::STXRX:
+  case AArch64::STLXRB:
+  case AArch64::STLXRH:
+  case AArch64::STLXRW:
+  case AArch64::STLXRX:
+    return MemInstInfo{2, -1, false, false};
+
+  // Exclusive pair loads: Rt, Rt2, [Rn]
+  case AArch64::LDXPW:
+  case AArch64::LDXPX:
+  case AArch64::LDAXPW:
+  case AArch64::LDAXPX:
+    return MemInstInfo{2, -1, false, false};
+
+    // Pair indexed loads/stores: Rt, Rt2, [Rn, #imm]
+#define X(NAME, SCALE) case AArch64::NAME##i:
+    PAIR_OPS(X)
+#undef X
+  case AArch64::LDNPDi:
+  case AArch64::LDNPQi:
+  case AArch64::LDNPSi:
+  case AArch64::LDNPWi:
+  case AArch64::LDNPXi:
+  case AArch64::STNPDi:
+  case AArch64::STNPQi:
+  case AArch64::STNPSi:
+  case AArch64::STNPWi:
+  case AArch64::STNPXi:
+    return MemInstInfo{2, 3, false, false};
+
+    // CAS: Rs(out), Rs(in, tied), Rt, [Rn]
+#define CAS_VARIANTS(NAME)                                                     \
+  case AArch64::NAME##B:                                                       \
+  case AArch64::NAME##H:                                                       \
+  case AArch64::NAME##W:                                                       \
+  case AArch64::NAME##X:
+    CAS_VARIANTS(CAS)
+    CAS_VARIANTS(CASA)
+    CAS_VARIANTS(CASL)
+    CAS_VARIANTS(CASAL)
+#undef CAS_VARIANTS
+    return MemInstInfo{3, -1, false, false};
+
+    // LSE atomics: Rs, Rt, [Rn] - all 16 size/ordering variants per operation.
+#define LSE_VARIANTS(NAME)                                                     \
+  case AArch64::NAME##B:                                                       \
+  case AArch64::NAME##H:                                                       \
+  case AArch64::NAME##W:                                                       \
+  case AArch64::NAME##X:                                                       \
+  case AArch64::NAME##AB:                                                      \
+  case AArch64::NAME##AH:                                                      \
+  case AArch64::NAME##AW:                                                      \
+  case AArch64::NAME##AX:                                                      \
+  case AArch64::NAME##LB:                                                      \
+  case AArch64::NAME##LH:                                                      \
+  case AArch64::NAME##LW:                                                      \
+  case AArch64::NAME##LX:                                                      \
+  case AArch64::NAME##ALB:                                                     \
+  case AArch64::NAME##ALH:                                                     \
+  case AArch64::NAME##ALW:                                                     \
+  case AArch64::NAME##ALX:
+    LSE_VARIANTS(LDADD)
+    LSE_VARIANTS(LDCLR)
+    LSE_VARIANTS(LDEOR)
+    LSE_VARIANTS(LDSET)
+    LSE_VARIANTS(LDSMAX)
+    LSE_VARIANTS(LDSMIN)
+    LSE_VARIANTS(LDUMAX)
+    LSE_VARIANTS(LDUMIN)
+    LSE_VARIANTS(SWP)
+#undef LSE_VARIANTS
+    // SIMD lane stores (base form): Vt, idx, [Rn]
+#define X(NAME, OFF) case AArch64::NAME:
+    SIMD_LANE_STORE_OPS(X)
+#undef X
+    return MemInstInfo{2, -1, false, false};
+
+    // SIMD lane loads (base form): Vt(out), Vt(tied), idx, [Rn]
+#define X(NAME, OFF) case AArch64::NAME:
+    SIMD_LANE_LOAD_OPS(X)
+#undef X
+    return MemInstInfo{3, -1, false, false};
+
+  // Exclusive store pairs: Ws, Rt, Rt2, [Rn]
+  case AArch64::STXPW:
+  case AArch64::STXPX:
+  case AArch64::STLXPW:
+  case AArch64::STLXPX:
+    return MemInstInfo{3, -1, false, false};
+
+    // Pair pre/post-index: wback, Rt, Rt2, [Rn, #imm]! / [Rn], #imm
+#define X(NAME, SCALE)                                                         \
+  case AArch64::NAME##pre:                                                     \
+  case AArch64::NAME##post:
+    PAIR_OPS(X)
+#undef X
+    return MemInstInfo{3, 4, true, false};
+
+  // CASP: Ws_Ws2(out), Ws_Ws2(in, tied), Wt_Wt2, [Rn]
+  case AArch64::CASPW:
+  case AArch64::CASPX:
+  case AArch64::CASPAW:
+  case AArch64::CASPAX:
+  case AArch64::CASPLW:
+  case AArch64::CASPLX:
+  case AArch64::CASPALW:
+  case AArch64::CASPALX:
+    return MemInstInfo{3, -1, false, false};
+
+    // SIMD multiple/replicate post-index: wback, Vt, [Rn], Xm
+#define X(NAME, OFF) case AArch64::NAME##_POST:
+    SIMD_MULTI_OPS(X)
+#undef X
+    return MemInstInfo{2, 3, true, false};
+
+    // SIMD lane store post-index: wback, Vt, idx, [Rn], Xm
+#define X(NAME, OFF) case AArch64::NAME##_POST:
+    SIMD_LANE_STORE_OPS(X)
+#undef X
+    return MemInstInfo{3, 4, true, false};
+
+    // SIMD lane load post-index: wback, Vt(out), Vt(tied), idx, [Rn], Xm
+#define X(NAME, OFF) case AArch64::NAME##_POST:
+    SIMD_LANE_LOAD_OPS(X)
+#undef X
+    return MemInstInfo{4, 5, true, false};
+  }
+}
+
+// RoW (Register-offset-W) Opcode Conversion Tables
+//
+// These tables convert various load/store addressing modes to the
+// register-offset-W form ([X27, Wn, uxtw]) which provides sandboxing in a
+// single instruction by zero-extending the 32-bit offset register.
+//
+// All scalar load/store instructions that support RoW addressing are listed
+// here. Each entry is (NAME, SHIFT) where NAME is the opcode base (e.g. LDRX)
+// and SHIFT is the log2 element size used for scaled addressing.
+static unsigned convertUiToRoW(unsigned Op) {
+  switch (Op) {
+#define X(NAME, S)                                                             \
+  case AArch64::NAME##ui:                                                      \
+    return AArch64::NAME##roW;
+    SCALAR_MEM_OPS(X)
+#undef X
+  case AArch64::PRFMui:
+    return AArch64::PRFMroW;
+  default:
+    return AArch64::INSTRUCTION_LIST_END;
+  }
+}
+
+static unsigned convertPreToRoW(unsigned Op) {
+  switch (Op) {
+#define X(NAME, S)                                                             \
+  case AArch64::NAME##pre:                                                     \
+    return AArch64::NAME##roW;
+    SCALAR_MEM_OPS(X)
+#undef X
+  default:
+    return AArch64::INSTRUCTION_LIST_END;
+  }
+}
+
+static unsigned convertPostToRoW(unsigned Op) {
+  switch (Op) {
+#define X(NAME, S)                                                             \
+  case AArch64::NAME##post:                                                    \
+    return AArch64::NAME##roW;
+    SCALAR_MEM_OPS(X)
+#undef X
+  default:
+    return AArch64::INSTRUCTION_LIST_END;
+  }
+}
+
+static unsigned convertRoXToRoW(unsigned Op, unsigned &Shift) {
+  Shift = 0;
+  switch (Op) {
+#define X(NAME, S)                                                             \
+  case AArch64::NAME##roX:                                                     \
+    Shift = S;                                                                 \
+    return AArch64::NAME##roW;
+    SCALAR_MEM_OPS(X)
+#undef X
+  case AArch64::PRFMroX:
+    Shift = 3;
+    return AArch64::PRFMroW;
+  default:
+    return AArch64::INSTRUCTION_LIST_END;
+  }
+}
+
+static bool getRoWShift(unsigned Op, unsigned &Shift) {
+  Shift = 0;
+  switch (Op) {
+#define X(NAME, S)                                                             \
+  case AArch64::NAME##roW:                                                     \
+    Shift = S;                                                                 \
+    return true;
+    SCALAR_MEM_OPS(X)
+#undef X
+  case AArch64::PRFMroW:
+    Shift = 3;
+    return true;
+  default:
+    return false;
+  }
+}
+
+// Pre/Post-Index to Base Conversion and Natural Offset Tables
+//
+// SIMD post-index instructions are listed once in SIMD_POST_OPS and used to
+// generate both convertPrePostToBase and getSIMDNaturalOffset.
+// Each entry is (NAME, OFFSET) where the post opcode is NAME##_POST, the base
+// opcode is NAME, and OFFSET is the natural byte increment.
+static unsigned convertPrePostToBase(unsigned Op, bool &IsPre,
+                                     bool &IsNoOffset) {
+  IsPre = false;
+  IsNoOffset = false;
+  switch (Op) {
+    // LDP/STP pairs.
+#define X(NAME, SCALE)                                                         \
+  case AArch64::NAME##post:                                                    \
+    return AArch64::NAME##i;                                                   \
+  case AArch64::NAME##pre:                                                     \
+    IsPre = true;                                                              \
+    return AArch64::NAME##i;
+    PAIR_OPS(X)
+#undef X
+    // SIMD post-index.
+#define X(NAME, OFF)                                                           \
+  case AArch64::NAME##_POST:                                                   \
+    IsNoOffset = true;                                                         \
+    return AArch64::NAME;
+    SIMD_POST_OPS(X)
+#undef X
+  default:
+    return AArch64::INSTRUCTION_LIST_END;
+  }
+}
+
+static unsigned getPrePostScale(unsigned Op) {
+  switch (Op) {
+#define X(NAME, SCALE)                                                         \
+  case AArch64::NAME##post:                                                    \
+  case AArch64::NAME##pre:                                                     \
+    return SCALE;
+    PAIR_OPS(X)
+#undef X
+  default:
+    return 1;
+  }
+}
+
+static int getSIMDNaturalOffset(unsigned Op) {
+  switch (Op) {
+#define X(NAME, OFF)                                                           \
+  case AArch64::NAME##_POST:                                                   \
+    return OFF;
+    SIMD_POST_OPS(X)
+#undef X
+  default:
+    return -1;
+  }
 }

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
@@ -415,7 +415,7 @@ bool AArch64MCLFIRewriter::rewriteLoadStoreRoW(const MCInst &Inst,
     return false;
   }
 
-  // Case 2: Pre-index load/store.
+  // Case 2: Pre-index load/store with writeback.
   // ldr xN, [xM, #imm]! -> add xM, xM, #imm; ldr xN, [x27, wM, uxtw]
   if ((MemOp = convertPreToRoW(Op)) != AArch64::INSTRUCTION_LIST_END) {
     MCRegister BaseReg = Inst.getOperand(2).getReg();

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.h
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_LIB_TARGET_AARCH64_MCTARGETDESC_AARCH64MCLFIREWRITER_H
 #define LLVM_LIB_TARGET_AARCH64_MCTARGETDESC_AARCH64MCLFIREWRITER_H
 
+#include "AArch64AddressingModes.h"
 #include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCLFIRewriter.h"
 #include "llvm/MC/MCRegister.h"
@@ -21,6 +22,7 @@
 namespace llvm {
 class MCContext;
 class MCInst;
+class MCOperand;
 class MCStreamer;
 class MCSubtargetInfo;
 
@@ -50,9 +52,12 @@ private:
   /// Recursion guard to prevent infinite loops when emitting instructions.
   bool Guard = false;
 
-  // Instruction classification. Returns the reserved register that may be
-  // modified, or an invalid register if no reserved register is touched.
+  // Instruction classification.
+
+  // Returns the reserved register that may be modified, or an invalid register
+  // if no reserved register is touched.
   MCRegister mayModifyReserved(const MCInst &Inst) const;
+  bool mayModifyStack(const MCInst &Inst) const;
 
   // Instruction emission.
   void emitInst(const MCInst &Inst, MCStreamer &Out,
@@ -63,6 +68,15 @@ private:
                   const MCSubtargetInfo &STI);
   void emitMov(MCRegister Dest, MCRegister Src, MCStreamer &Out,
                const MCSubtargetInfo &STI);
+  void emitAddImm(MCRegister Dest, MCRegister Src, int64_t Imm, MCStreamer &Out,
+                  const MCSubtargetInfo &STI);
+  void emitAddReg(MCRegister Dest, MCRegister Src1, MCRegister Src2,
+                  unsigned Shift, MCStreamer &Out, const MCSubtargetInfo &STI);
+  void emitAddRegExtend(MCRegister Dest, MCRegister Src1, MCRegister Src2,
+                        AArch64_AM::ShiftExtendType ExtType, unsigned Shift,
+                        MCStreamer &Out, const MCSubtargetInfo &STI);
+  void emitMemRoW(unsigned Opcode, const MCOperand &DataOp, MCRegister BaseReg,
+                  MCStreamer &Out, const MCSubtargetInfo &STI);
 
   // Rewriting logic.
   void doRewriteInst(const MCInst &Inst, MCStreamer &Out,
@@ -73,6 +87,18 @@ private:
                              const MCSubtargetInfo &STI);
   void rewriteReturn(const MCInst &Inst, MCStreamer &Out,
                      const MCSubtargetInfo &STI);
+
+  // Memory access.
+  void rewriteLoadStore(const MCInst &Inst, MCStreamer &Out,
+                        const MCSubtargetInfo &STI);
+  void rewriteLoadStoreBasic(const MCInst &Inst, MCStreamer &Out,
+                             const MCSubtargetInfo &STI);
+  bool rewriteLoadStoreRoW(const MCInst &Inst, MCStreamer &Out,
+                           const MCSubtargetInfo &STI);
+
+  // Register modification.
+  void rewriteStackModification(const MCInst &Inst, MCStreamer &Out,
+                                const MCSubtargetInfo &STI);
 
   // Link register modification.
   void rewriteLRModification(const MCInst &Inst, MCStreamer &Out,
@@ -85,7 +111,14 @@ private:
                      const MCSubtargetInfo &STI);
   void rewriteTPWrite(const MCInst &Inst, MCStreamer &Out,
                       const MCSubtargetInfo &STI);
+  void rewriteVASysOp(const MCInst &Inst, MCStreamer &Out,
+                      const MCSubtargetInfo &STI);
 };
+
+/// Returns true if \p Opcode is a pre- or post-indexed memory access that the
+/// LFI rewriter expands with a base-register update (i.e. an extra
+/// instruction beyond the guard + access pair).
+bool isLFIPrePostMemAccess(unsigned Opcode);
 
 } // namespace llvm
 

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.h
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.h
@@ -57,7 +57,7 @@ private:
   // Returns the reserved register that may be modified, or an invalid register
   // if no reserved register is touched.
   MCRegister mayModifyReserved(const MCInst &Inst) const;
-  bool mayModifyStack(const MCInst &Inst) const;
+  bool mayModifySP(const MCInst &Inst) const;
 
   // Instruction emission.
   void emitInst(const MCInst &Inst, MCStreamer &Out,
@@ -91,14 +91,14 @@ private:
   // Memory access.
   void rewriteLoadStore(const MCInst &Inst, MCStreamer &Out,
                         const MCSubtargetInfo &STI);
-  void rewriteLoadStoreBasic(const MCInst &Inst, MCStreamer &Out,
-                             const MCSubtargetInfo &STI);
+  void rewriteLoadStoreBase(const MCInst &Inst, MCStreamer &Out,
+                            const MCSubtargetInfo &STI);
   bool rewriteLoadStoreRoW(const MCInst &Inst, MCStreamer &Out,
                            const MCSubtargetInfo &STI);
 
-  // Register modification.
-  void rewriteStackModification(const MCInst &Inst, MCStreamer &Out,
-                                const MCSubtargetInfo &STI);
+  // SP register modification.
+  void rewriteSPModification(const MCInst &Inst, MCStreamer &Out,
+                             const MCSubtargetInfo &STI);
 
   // Link register modification.
   void rewriteLRModification(const MCInst &Inst, MCStreamer &Out,

--- a/llvm/test/MC/AArch64/LFI/exclusive.s
+++ b/llvm/test/MC/AArch64/LFI/exclusive.s
@@ -1,0 +1,140 @@
+// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+
+// Load exclusive
+ldxr x0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldxr x0, [x28]
+
+ldxr w0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldxr w0, [x28]
+
+ldxrb w0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldxrb w0, [x28]
+
+ldxrh w0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldxrh w0, [x28]
+
+// Store exclusive
+stxr w0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: stxr w0, x1, [x28]
+
+stxr w0, w1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: stxr w0, w1, [x28]
+
+stxrb w0, w1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: stxrb w0, w1, [x28]
+
+stxrh w0, w1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: stxrh w0, w1, [x28]
+
+// Load-acquire exclusive
+ldaxr x0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldaxr x0, [x28]
+
+ldaxr w0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldaxr w0, [x28]
+
+ldaxrb w0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldaxrb w0, [x28]
+
+ldaxrh w0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldaxrh w0, [x28]
+
+// Store-release exclusive
+stlxr w0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: stlxr w0, x1, [x28]
+
+stlxr w0, w1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: stlxr w0, w1, [x28]
+
+stlxrb w0, w1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: stlxrb w0, w1, [x28]
+
+stlxrh w0, w1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: stlxrh w0, w1, [x28]
+
+// Exclusive pairs
+ldxp x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldxp x0, x1, [x28]
+
+ldxp w0, w1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldxp w0, w1, [x28]
+
+stxp w0, x1, x2, [x3]
+// CHECK:      add x28, x27, w3, uxtw
+// CHECK-NEXT: stxp w0, x1, x2, [x28]
+
+stxp w0, w1, w2, [x3]
+// CHECK:      add x28, x27, w3, uxtw
+// CHECK-NEXT: stxp w0, w1, w2, [x28]
+
+ldaxp x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldaxp x0, x1, [x28]
+
+stlxp w0, x1, x2, [x3]
+// CHECK:      add x28, x27, w3, uxtw
+// CHECK-NEXT: stlxp w0, x1, x2, [x28]
+
+// Load-acquire / Store-release (non-exclusive)
+ldar x0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldar x0, [x28]
+
+ldar w0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldar w0, [x28]
+
+ldarb w0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldarb w0, [x28]
+
+ldarh w0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldarh w0, [x28]
+
+stlr x0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: stlr x0, [x28]
+
+stlr w0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: stlr w0, [x28]
+
+stlrb w0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: stlrb w0, [x28]
+
+stlrh w0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: stlrh w0, [x28]
+
+// SP-relative exclusive (no sandboxing needed)
+ldxr x0, [sp]
+// CHECK: ldxr x0, [sp]
+
+stxr w0, x1, [sp]
+// CHECK: stxr w0, x1, [sp]
+
+ldar x0, [sp]
+// CHECK: ldar x0, [sp]
+
+stlr x0, [sp]
+// CHECK: stlr x0, [sp]

--- a/llvm/test/MC/AArch64/LFI/fp.s
+++ b/llvm/test/MC/AArch64/LFI/fp.s
@@ -1,0 +1,204 @@
+// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+
+// FP/SIMD scalar loads (zero offset -> RoW)
+ldr b0, [x1]
+// CHECK: ldr b0, [x27, w1, uxtw]
+
+ldr h0, [x1]
+// CHECK: ldr h0, [x27, w1, uxtw]
+
+ldr s0, [x1]
+// CHECK: ldr s0, [x27, w1, uxtw]
+
+ldr d0, [x1]
+// CHECK: ldr d0, [x27, w1, uxtw]
+
+ldr q0, [x1]
+// CHECK: ldr q0, [x27, w1, uxtw]
+
+// FP/SIMD scalar stores (zero offset -> RoW)
+str b0, [x1]
+// CHECK: str b0, [x27, w1, uxtw]
+
+str h0, [x1]
+// CHECK: str h0, [x27, w1, uxtw]
+
+str s0, [x1]
+// CHECK: str s0, [x27, w1, uxtw]
+
+str d0, [x1]
+// CHECK: str d0, [x27, w1, uxtw]
+
+str q0, [x1]
+// CHECK: str q0, [x27, w1, uxtw]
+
+// FP loads with non-zero offset (demoted)
+ldr s0, [x1, #4]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldr s0, [x28, #4]
+
+ldr d0, [x1, #8]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldr d0, [x28, #8]
+
+ldr q0, [x1, #16]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldr q0, [x28, #16]
+
+// FP stores with non-zero offset (demoted)
+str s0, [x1, #4]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: str s0, [x28, #4]
+
+str d0, [x1, #8]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: str d0, [x28, #8]
+
+str q0, [x1, #16]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: str q0, [x28, #16]
+
+// FP pre-index
+ldr s0, [x1, #4]!
+// CHECK:      add x1, x1, #4
+// CHECK-NEXT: ldr s0, [x27, w1, uxtw]
+
+ldr d0, [x1, #8]!
+// CHECK:      add x1, x1, #8
+// CHECK-NEXT: ldr d0, [x27, w1, uxtw]
+
+ldr q0, [x1, #16]!
+// CHECK:      add x1, x1, #16
+// CHECK-NEXT: ldr q0, [x27, w1, uxtw]
+
+str s0, [x1, #4]!
+// CHECK:      add x1, x1, #4
+// CHECK-NEXT: str s0, [x27, w1, uxtw]
+
+// FP post-index
+ldr s0, [x1], #4
+// CHECK:      ldr s0, [x27, w1, uxtw]
+// CHECK-NEXT: add x1, x1, #4
+
+ldr d0, [x1], #8
+// CHECK:      ldr d0, [x27, w1, uxtw]
+// CHECK-NEXT: add x1, x1, #8
+
+ldr q0, [x1], #16
+// CHECK:      ldr q0, [x27, w1, uxtw]
+// CHECK-NEXT: add x1, x1, #16
+
+str d0, [x1], #8
+// CHECK:      str d0, [x27, w1, uxtw]
+// CHECK-NEXT: add x1, x1, #8
+
+// FP register offset
+ldr s0, [x1, x2]
+// CHECK:      add x26, x1, x2
+// CHECK-NEXT: ldr s0, [x27, w26, uxtw]
+
+ldr d0, [x1, x2, lsl #3]
+// CHECK:      add x26, x1, x2, lsl #3
+// CHECK-NEXT: ldr d0, [x27, w26, uxtw]
+
+ldr q0, [x1, x2, lsl #4]
+// CHECK:      add x26, x1, x2, lsl #4
+// CHECK-NEXT: ldr q0, [x27, w26, uxtw]
+
+str s0, [x1, x2, lsl #2]
+// CHECK:      add x26, x1, x2, lsl #2
+// CHECK-NEXT: str s0, [x27, w26, uxtw]
+
+str d0, [x1, w2, sxtw]
+// CHECK:      add x26, x1, w2, sxtw
+// CHECK-NEXT: str d0, [x27, w26, uxtw]
+
+str q0, [x1, w2, uxtw #4]
+// CHECK:      add x26, x1, w2, uxtw #4
+// CHECK-NEXT: str q0, [x27, w26, uxtw]
+
+// FP unscaled offset
+ldur s0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldur s0, [x28]
+
+ldur d0, [x1, #8]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldur d0, [x28, #8]
+
+ldur q0, [x1, #-16]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldur q0, [x28, #-16]
+
+stur s0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: stur s0, [x28]
+
+stur d0, [x1, #8]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: stur d0, [x28, #8]
+
+// FP pair loads/stores
+ldp s0, s1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldp s0, s1, [x28]
+
+ldp d0, d1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldp d0, d1, [x28]
+
+ldp q0, q1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldp q0, q1, [x28]
+
+stp s0, s1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: stp s0, s1, [x28]
+
+stp d0, d1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: stp d0, d1, [x28]
+
+stp q0, q1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: stp q0, q1, [x28]
+
+// FP pair with offset
+ldp s0, s1, [x2, #8]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldp s0, s1, [x28, #8]
+
+ldp d0, d1, [x2, #16]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldp d0, d1, [x28, #16]
+
+// FP pair pre/post-index
+ldp s0, s1, [x2], #8
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldp s0, s1, [x28]
+// CHECK-NEXT: add x2, x2, #8
+
+ldp d0, d1, [x2, #16]!
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldp d0, d1, [x28, #16]
+// CHECK-NEXT: add x2, x2, #16
+
+stp q0, q1, [x2], #32
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: stp q0, q1, [x28]
+// CHECK-NEXT: add x2, x2, #32
+
+stp d0, d1, [x2, #-16]!
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: stp d0, d1, [x28, #-16]
+// CHECK-NEXT: sub x2, x2, #16
+
+// SP-relative FP loads (no sandboxing needed)
+ldr s0, [sp]
+// CHECK: ldr s0, [sp]
+
+ldr d0, [sp, #8]
+// CHECK: ldr d0, [sp, #8]
+
+ldp q0, q1, [sp, #32]
+// CHECK: ldp q0, q1, [sp, #32]

--- a/llvm/test/MC/AArch64/LFI/jumps-only.s
+++ b/llvm/test/MC/AArch64/LFI/jumps-only.s
@@ -1,0 +1,41 @@
+// RUN: llvm-mc -triple aarch64_lfi -mattr=+no-lfi-loads,+no-lfi-stores %s | FileCheck %s
+
+// Jumps-only mode: only branches are sandboxed.
+
+ldr x0, [x1]
+// CHECK: ldr x0, [x1]
+
+ldr x0, [x1, #8]
+// CHECK: ldr x0, [x1, #8]
+
+str x0, [x1]
+// CHECK: str x0, [x1]
+
+stp x0, x1, [x2, #16]
+// CHECK: stp x0, x1, [x2, #16]
+
+add sp, sp, #8
+// CHECK: add sp, sp, #8
+
+sub sp, sp, #8
+// CHECK: sub sp, sp, #8
+
+mov sp, x0
+// CHECK: mov sp, x0
+
+br x0
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: br x28
+
+ret
+// CHECK: ret
+
+blr x1
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: blr x28
+
+bl some_func
+// CHECK: bl some_func
+
+b some_func
+// CHECK: b some_func

--- a/llvm/test/MC/AArch64/LFI/literal.s
+++ b/llvm/test/MC/AArch64/LFI/literal.s
@@ -1,0 +1,37 @@
+// RUN: not llvm-mc -triple aarch64_lfi %s 2>&1 | FileCheck %s
+
+ldr x0, foo
+// CHECK: error: PC-relative literal loads are not supported in LFI
+
+ldr w0, bar
+// CHECK: error: PC-relative literal loads are not supported in LFI
+
+ldr s0, baz
+// CHECK: error: PC-relative literal loads are not supported in LFI
+
+ldr d0, qux
+// CHECK: error: PC-relative literal loads are not supported in LFI
+
+ldr q0, quux
+// CHECK: error: PC-relative literal loads are not supported in LFI
+
+ldrsw x0, signed_word
+// CHECK: error: PC-relative literal loads are not supported in LFI
+
+prfm pldl1keep, prefetch_target
+// CHECK: error: PC-relative literal loads are not supported in LFI
+
+foo:
+  .quad 0
+bar:
+  .word 0
+baz:
+  .single 0.0
+qux:
+  .double 0.0
+quux:
+  .zero 16
+signed_word:
+  .word -1
+prefetch_target:
+  .quad 0

--- a/llvm/test/MC/AArch64/LFI/lse.s
+++ b/llvm/test/MC/AArch64/LFI/lse.s
@@ -1,5 +1,5 @@
 // RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
-// RUN: llvm-mc -triple aarch64_lfi -mattr=+no-lfi-loads %s | FileCheck %s --check-prefix=NOLOADS
+// RUN: llvm-mc -triple aarch64_lfi -mattr=+no-lfi-loads %s | FileCheck %s
 
 .arch_extension lse
 
@@ -8,8 +8,6 @@
 ldadd x0, x1, [x2]
 // CHECK:      add x28, x27, w2, uxtw
 // CHECK-NEXT: ldadd x0, x1, [x28]
-// NOLOADS:      add x28, x27, w2, uxtw
-// NOLOADS-NEXT: ldadd x0, x1, [x28]
 
 ldadd w0, w1, [x2]
 // CHECK:      add x28, x27, w2, uxtw
@@ -74,7 +72,6 @@ ldseta x0, x1, [x2]
 swp x0, x1, [x2]
 // CHECK:      add x28, x27, w2, uxtw
 // CHECK-NEXT: swp x0, x1, [x28]
-// NOLOADS:      swp x0, x1, [x28]
 
 swpa x0, x1, [x2]
 // CHECK:      add x28, x27, w2, uxtw
@@ -112,7 +109,6 @@ swpal w0, w0, [x1]
 cas x0, x1, [x2]
 // CHECK:      add x28, x27, w2, uxtw
 // CHECK-NEXT: cas x0, x1, [x28]
-// NOLOADS:      cas x0, x1, [x28]
 
 casa x0, x1, [x2]
 // CHECK:      add x28, x27, w2, uxtw

--- a/llvm/test/MC/AArch64/LFI/lse.s
+++ b/llvm/test/MC/AArch64/LFI/lse.s
@@ -1,0 +1,166 @@
+// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64_lfi -mattr=+no-lfi-loads %s | FileCheck %s --check-prefix=NOLOADS
+
+.arch_extension lse
+
+// LDADD variants
+// Atomics are both loads and stores, so +no-lfi-loads must still sandbox them.
+ldadd x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldadd x0, x1, [x28]
+// NOLOADS:      add x28, x27, w2, uxtw
+// NOLOADS-NEXT: ldadd x0, x1, [x28]
+
+ldadd w0, w1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldadd w0, w1, [x28]
+
+ldadda x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldadda x0, x1, [x28]
+
+ldaddal x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldaddal x0, x1, [x28]
+
+ldaddl x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldaddl x0, x1, [x28]
+
+ldaddab w0, w1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldaddab w0, w1, [x28]
+
+ldaddah w0, w1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldaddah w0, w1, [x28]
+
+// LDCLR variants
+ldclr x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldclr x0, x1, [x28]
+
+ldclra x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldclra x0, x1, [x28]
+
+ldclral x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldclral x0, x1, [x28]
+
+ldclrl x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldclrl x0, x1, [x28]
+
+// LDEOR variants
+ldeor x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldeor x0, x1, [x28]
+
+ldeora x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldeora x0, x1, [x28]
+
+// LDSET variants
+ldset x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldset x0, x1, [x28]
+
+ldseta x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldseta x0, x1, [x28]
+
+// SWP variants
+swp x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: swp x0, x1, [x28]
+// NOLOADS:      swp x0, x1, [x28]
+
+swpa x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: swpa x0, x1, [x28]
+
+swpal x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: swpal x0, x1, [x28]
+
+swpl x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: swpl x0, x1, [x28]
+
+swpab w0, w1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: swpab w0, w1, [x28]
+
+swpah w0, w1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: swpah w0, w1, [x28]
+
+swpalb w0, w1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: swpalb w0, w1, [x28]
+
+swpalh w0, w1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: swpalh w0, w1, [x28]
+
+swpal w0, w0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: swpal w0, w0, [x28]
+
+// CAS variants
+cas x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: cas x0, x1, [x28]
+// NOLOADS:      cas x0, x1, [x28]
+
+casa x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: casa x0, x1, [x28]
+
+casal x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: casal x0, x1, [x28]
+
+casl x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: casl x0, x1, [x28]
+
+casab w0, w1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: casab w0, w1, [x28]
+
+casah w0, w1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: casah w0, w1, [x28]
+
+// CASP variants (pair)
+casp x0, x1, x2, x3, [x4]
+// CHECK:      add x28, x27, w4, uxtw
+// CHECK-NEXT: casp x0, x1, x2, x3, [x28]
+
+caspa x0, x1, x2, x3, [x4]
+// CHECK:      add x28, x27, w4, uxtw
+// CHECK-NEXT: caspa x0, x1, x2, x3, [x28]
+
+caspal x0, x1, x2, x3, [x4]
+// CHECK:      add x28, x27, w4, uxtw
+// CHECK-NEXT: caspal x0, x1, x2, x3, [x28]
+
+caspl x0, x1, x2, x3, [x4]
+// CHECK:      add x28, x27, w4, uxtw
+// CHECK-NEXT: caspl x0, x1, x2, x3, [x28]
+
+caspal w0, w1, w2, w3, [x4]
+// CHECK:      add x28, x27, w4, uxtw
+// CHECK-NEXT: caspal w0, w1, w2, w3, [x28]
+
+// SP-relative atomics (no sandboxing needed)
+ldadd x0, x1, [sp]
+// CHECK: ldadd x0, x1, [sp]
+
+swp x0, x1, [sp]
+// CHECK: swp x0, x1, [sp]
+
+cas x0, x1, [sp]
+// CHECK: cas x0, x1, [sp]

--- a/llvm/test/MC/AArch64/LFI/mem-lr.s
+++ b/llvm/test/MC/AArch64/LFI/mem-lr.s
@@ -1,0 +1,71 @@
+// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+
+// Memory accesses that define LR (x30) must sandbox the base register
+// in addition to masking LR after the access.
+
+ldr x30, [x0, #0x100]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ldr x30, [x28, #256]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldr x30, [x0]
+// CHECK:      ldr x30, [x27, w0, uxtw]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldr x30, [x0, #8]!
+// CHECK:      add x0, x0, #8
+// CHECK-NEXT: ldr x30, [x27, w0, uxtw]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldr x30, [x0, #-8]!
+// CHECK:      sub x0, x0, #8
+// CHECK-NEXT: ldr x30, [x27, w0, uxtw]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldr x30, [x0], #8
+// CHECK:      ldr x30, [x27, w0, uxtw]
+// CHECK-NEXT: add x0, x0, #8
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldr x30, [x0, x1]
+// CHECK:      add x26, x0, x1
+// CHECK-NEXT: ldr x30, [x27, w26, uxtw]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldr x30, [x0, x1, lsl #3]
+// CHECK:      add x26, x0, x1, lsl #3
+// CHECK-NEXT: ldr x30, [x27, w26, uxtw]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldur x30, [x0, #4]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ldur x30, [x28, #4]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldp x29, x30, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ldp x29, x30, [x28]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldp x29, x30, [x0, #16]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ldp x29, x30, [x28, #16]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldp x29, x30, [x0, #16]!
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ldp x29, x30, [x28, #16]
+// CHECK-NEXT: add x0, x0, #16
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldp x29, x30, [x0], #16
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ldp x29, x30, [x28]
+// CHECK-NEXT: add x0, x0, #16
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+// SP-based LR loads are safe without base sandboxing.
+
+ldr x30, [sp, #16]
+// CHECK:      ldr x30, [sp, #16]
+// CHECK-NEXT: add x30, x27, w30, uxtw

--- a/llvm/test/MC/AArch64/LFI/mem.s
+++ b/llvm/test/MC/AArch64/LFI/mem.s
@@ -1,5 +1,6 @@
 // RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
 
+// SP-relative loads/stores (no sandboxing needed)
 ldr x0, [sp]
 // CHECK: ldr x0, [sp]
 
@@ -132,33 +133,6 @@ stp x0, x1, [x2, #-8]!
 // CHECK:      add x28, x27, w2, uxtw
 // CHECK-NEXT: stp x0, x1, [x28, #-8]
 // CHECK-NEXT: sub x2, x2, #8
-
-ld3 { v0.4s, v1.4s, v2.4s }, [x0], #48
-// CHECK:      add x28, x27, w0, uxtw
-// CHECK-NEXT: ld3 { v0.4s, v1.4s, v2.4s }, [x28]
-// CHECK-NEXT: add x0, x0, #48
-
-st2 { v1.8b, v2.8b }, [x14], #16
-// CHECK:      add x28, x27, w14, uxtw
-// CHECK-NEXT: st2 { v1.8b, v2.8b }, [x28]
-// CHECK-NEXT: add x14, x14, #16
-
-st2 { v1.8b, v2.8b }, [x14]
-// CHECK:      add x28, x27, w14, uxtw
-// CHECK-NEXT: st2 { v1.8b, v2.8b }, [x28]
-
-ld1 { v0.s }[1], [x8]
-// CHECK:      add x28, x27, w8, uxtw
-// CHECK-NEXT: ld1 { v0.s }[1], [x28]
-
-ld1r { v3.2d }, [x9]
-// CHECK:      add x28, x27, w9, uxtw
-// CHECK-NEXT: ld1r { v3.2d }, [x28]
-
-ld1 { v0.s }[1], [x8], x10
-// CHECK:      add x28, x27, w8, uxtw
-// CHECK-NEXT: ld1 { v0.s }[1], [x28]
-// CHECK-NEXT: add x8, x8, x10
 
 ldaxr x0, [x2]
 // CHECK:      add x28, x27, w2, uxtw
@@ -435,73 +409,3 @@ stp w0, w1, [x2, #8]!
 // CHECK:      add x28, x27, w2, uxtw
 // CHECK-NEXT: stp w0, w1, [x28, #8]
 // CHECK-NEXT: add x2, x2, #8
-
-// Memory accesses that define LR (x30) must sandbox the base register
-// in addition to masking LR after the access.
-
-ldr x30, [x0, #0x100]
-// CHECK:      add x28, x27, w0, uxtw
-// CHECK-NEXT: ldr x30, [x28, #256]
-// CHECK-NEXT: add x30, x27, w30, uxtw
-
-ldr x30, [x0]
-// CHECK:      ldr x30, [x27, w0, uxtw]
-// CHECK-NEXT: add x30, x27, w30, uxtw
-
-ldr x30, [x0, #8]!
-// CHECK:      add x0, x0, #8
-// CHECK-NEXT: ldr x30, [x27, w0, uxtw]
-// CHECK-NEXT: add x30, x27, w30, uxtw
-
-ldr x30, [x0, #-8]!
-// CHECK:      sub x0, x0, #8
-// CHECK-NEXT: ldr x30, [x27, w0, uxtw]
-// CHECK-NEXT: add x30, x27, w30, uxtw
-
-ldr x30, [x0], #8
-// CHECK:      ldr x30, [x27, w0, uxtw]
-// CHECK-NEXT: add x0, x0, #8
-// CHECK-NEXT: add x30, x27, w30, uxtw
-
-ldr x30, [x0, x1]
-// CHECK:      add x26, x0, x1
-// CHECK-NEXT: ldr x30, [x27, w26, uxtw]
-// CHECK-NEXT: add x30, x27, w30, uxtw
-
-ldr x30, [x0, x1, lsl #3]
-// CHECK:      add x26, x0, x1, lsl #3
-// CHECK-NEXT: ldr x30, [x27, w26, uxtw]
-// CHECK-NEXT: add x30, x27, w30, uxtw
-
-ldur x30, [x0, #4]
-// CHECK:      add x28, x27, w0, uxtw
-// CHECK-NEXT: ldur x30, [x28, #4]
-// CHECK-NEXT: add x30, x27, w30, uxtw
-
-ldp x29, x30, [x0]
-// CHECK:      add x28, x27, w0, uxtw
-// CHECK-NEXT: ldp x29, x30, [x28]
-// CHECK-NEXT: add x30, x27, w30, uxtw
-
-ldp x29, x30, [x0, #16]
-// CHECK:      add x28, x27, w0, uxtw
-// CHECK-NEXT: ldp x29, x30, [x28, #16]
-// CHECK-NEXT: add x30, x27, w30, uxtw
-
-ldp x29, x30, [x0, #16]!
-// CHECK:      add x28, x27, w0, uxtw
-// CHECK-NEXT: ldp x29, x30, [x28, #16]
-// CHECK-NEXT: add x0, x0, #16
-// CHECK-NEXT: add x30, x27, w30, uxtw
-
-ldp x29, x30, [x0], #16
-// CHECK:      add x28, x27, w0, uxtw
-// CHECK-NEXT: ldp x29, x30, [x28]
-// CHECK-NEXT: add x0, x0, #16
-// CHECK-NEXT: add x30, x27, w30, uxtw
-
-// SP-based LR loads are safe without base sandboxing.
-
-ldr x30, [sp, #16]
-// CHECK:      ldr x30, [sp, #16]
-// CHECK-NEXT: add x30, x27, w30, uxtw

--- a/llvm/test/MC/AArch64/LFI/mem.s
+++ b/llvm/test/MC/AArch64/LFI/mem.s
@@ -1,0 +1,507 @@
+// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+
+ldr x0, [sp]
+// CHECK: ldr x0, [sp]
+
+ldr x0, [sp, #8]
+// CHECK: ldr x0, [sp, #8]
+
+ldp x0, x1, [sp, #8]
+// CHECK: ldp x0, x1, [sp, #8]
+
+str x0, [sp]
+// CHECK: str x0, [sp]
+
+str x0, [sp, #8]
+// CHECK: str x0, [sp, #8]
+
+stp x0, x1, [sp, #8]
+// CHECK: stp x0, x1, [sp, #8]
+
+ldur x0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldur x0, [x28]
+
+stur x0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: stur x0, [x28]
+
+ldp x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldp x0, x1, [x28]
+
+stp x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: stp x0, x1, [x28]
+
+ldr x0, [x1]
+// CHECK: ldr x0, [x27, w1, uxtw]
+
+ldr x0, [x1, #8]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldr x0, [x28, #8]
+
+ldr x0, [x1, #8]!
+// CHECK:      add x1, x1, #8
+// CHECK-NEXT: ldr x0, [x27, w1, uxtw]
+
+str x0, [x1, #8]!
+// CHECK:      add x1, x1, #8
+// CHECK-NEXT: str x0, [x27, w1, uxtw]
+
+ldr x0, [x1, #-8]!
+// CHECK:      sub x1, x1, #8
+// CHECK-NEXT: ldr x0, [x27, w1, uxtw]
+
+str x0, [x1, #-8]!
+// CHECK:      sub x1, x1, #8
+// CHECK-NEXT: str x0, [x27, w1, uxtw]
+
+ldr x0, [x1], #8
+// CHECK:      ldr x0, [x27, w1, uxtw]
+// CHECK-NEXT: add x1, x1, #8
+
+str x0, [x1], #8
+// CHECK:      str x0, [x27, w1, uxtw]
+// CHECK-NEXT: add x1, x1, #8
+
+ldr x0, [x1], #-8
+// CHECK:      ldr x0, [x27, w1, uxtw]
+// CHECK-NEXT: sub x1, x1, #8
+
+str x0, [x1], #-8
+// CHECK:      str x0, [x27, w1, uxtw]
+// CHECK-NEXT: sub x1, x1, #8
+
+ldr x0, [x1, x2]
+// CHECK:      add x26, x1, x2
+// CHECK-NEXT: ldr x0, [x27, w26, uxtw]
+
+ldr x0, [x1, x2, lsl #3]
+// CHECK:      add x26, x1, x2, lsl #3
+// CHECK-NEXT: ldr x0, [x27, w26, uxtw]
+
+ldr x0, [x1, x2, sxtx #0]
+// CHECK:      add x26, x1, x2, sxtx
+// CHECK-NEXT: ldr x0, [x27, w26, uxtw]
+
+ldr x0, [x1, x2, sxtx #3]
+// CHECK:      add x26, x1, x2, sxtx #3
+// CHECK-NEXT: ldr x0, [x27, w26, uxtw]
+
+ldr x0, [x1, w2, uxtw]
+// CHECK:      add x26, x1, w2, uxtw
+// CHECK-NEXT: ldr x0, [x27, w26, uxtw]
+
+ldr x0, [x1, w2, uxtw #3]
+// CHECK:      add x26, x1, w2, uxtw #3
+// CHECK-NEXT: ldr x0, [x27, w26, uxtw]
+
+ldr x0, [x1, w2, sxtw]
+// CHECK:      add x26, x1, w2, sxtw
+// CHECK-NEXT: ldr x0, [x27, w26, uxtw]
+
+ldr x0, [x1, w2, sxtw #3]
+// CHECK:      add x26, x1, w2, sxtw #3
+// CHECK-NEXT: ldr x0, [x27, w26, uxtw]
+
+ldp x0, x1, [sp], #8
+// CHECK: ldp x0, x1, [sp], #8
+
+ldp x0, x1, [x2], #8
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldp x0, x1, [x28]
+// CHECK-NEXT: add x2, x2, #8
+
+ldp x0, x1, [x2, #8]!
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldp x0, x1, [x28, #8]
+// CHECK-NEXT: add x2, x2, #8
+
+ldp x0, x1, [x2], #-8
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldp x0, x1, [x28]
+// CHECK-NEXT: sub x2, x2, #8
+
+ldp x0, x1, [x2, #-8]!
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldp x0, x1, [x28, #-8]
+// CHECK-NEXT: sub x2, x2, #8
+
+stp x0, x1, [x2, #-8]!
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: stp x0, x1, [x28, #-8]
+// CHECK-NEXT: sub x2, x2, #8
+
+ld3 { v0.4s, v1.4s, v2.4s }, [x0], #48
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld3 { v0.4s, v1.4s, v2.4s }, [x28]
+// CHECK-NEXT: add x0, x0, #48
+
+st2 { v1.8b, v2.8b }, [x14], #16
+// CHECK:      add x28, x27, w14, uxtw
+// CHECK-NEXT: st2 { v1.8b, v2.8b }, [x28]
+// CHECK-NEXT: add x14, x14, #16
+
+st2 { v1.8b, v2.8b }, [x14]
+// CHECK:      add x28, x27, w14, uxtw
+// CHECK-NEXT: st2 { v1.8b, v2.8b }, [x28]
+
+ld1 { v0.s }[1], [x8]
+// CHECK:      add x28, x27, w8, uxtw
+// CHECK-NEXT: ld1 { v0.s }[1], [x28]
+
+ld1r { v3.2d }, [x9]
+// CHECK:      add x28, x27, w9, uxtw
+// CHECK-NEXT: ld1r { v3.2d }, [x28]
+
+ld1 { v0.s }[1], [x8], x10
+// CHECK:      add x28, x27, w8, uxtw
+// CHECK-NEXT: ld1 { v0.s }[1], [x28]
+// CHECK-NEXT: add x8, x8, x10
+
+ldaxr x0, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldaxr x0, [x28]
+
+stlxr w15, w17, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: stlxr w15, w17, [x28]
+
+ldr w4, [sp, w3, uxtw #2]
+// CHECK:      add x26, sp, w3, uxtw #2
+// CHECK-NEXT: ldr w4, [x27, w26, uxtw]
+
+stxrb w11, w10, [x8]
+// CHECK:      add x28, x27, w8, uxtw
+// CHECK-NEXT: stxrb w11, w10, [x28]
+
+ldr x0, [x0, :got_lo12:x]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ldr x0, [x28, :got_lo12:x]
+
+prfm pstl1strm, [x10]
+// CHECK: prfm pstl1strm, [x27, w10, uxtw]
+
+prfm pstl1strm, [x10, x11]
+// CHECK:      add x26, x10, x11
+// CHECK-NEXT: prfm pstl1strm, [x27, w26, uxtw]
+
+// Byte loads/stores
+ldrb w0, [x1]
+// CHECK: ldrb w0, [x27, w1, uxtw]
+
+ldrb w0, [x1, #1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldrb w0, [x28, #1]
+
+strb w0, [x1]
+// CHECK: strb w0, [x27, w1, uxtw]
+
+ldrsb w0, [x1]
+// CHECK: ldrsb w0, [x27, w1, uxtw]
+
+ldrsb x0, [x1]
+// CHECK: ldrsb x0, [x27, w1, uxtw]
+
+// Halfword loads/stores
+ldrh w0, [x1]
+// CHECK: ldrh w0, [x27, w1, uxtw]
+
+ldrh w0, [x1, #2]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldrh w0, [x28, #2]
+
+strh w0, [x1]
+// CHECK: strh w0, [x27, w1, uxtw]
+
+ldrsh w0, [x1]
+// CHECK: ldrsh w0, [x27, w1, uxtw]
+
+ldrsh x0, [x1]
+// CHECK: ldrsh x0, [x27, w1, uxtw]
+
+// Word loads/stores
+ldr w0, [x1]
+// CHECK: ldr w0, [x27, w1, uxtw]
+
+ldr w0, [x1, #4]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldr w0, [x28, #4]
+
+str w0, [x1]
+// CHECK: str w0, [x27, w1, uxtw]
+
+ldrsw x0, [x1]
+// CHECK: ldrsw x0, [x27, w1, uxtw]
+
+// 32-bit pairs
+ldp w0, w1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldp w0, w1, [x28]
+
+stp w0, w1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: stp w0, w1, [x28]
+
+// Unscaled loads/stores
+ldurb w0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldurb w0, [x28]
+
+ldurb w0, [x1, #1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldurb w0, [x28, #1]
+
+ldursb w0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldursb w0, [x28]
+
+ldurh w0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldurh w0, [x28]
+
+ldursh w0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldursh w0, [x28]
+
+ldur w0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldur w0, [x28]
+
+ldursw x0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldursw x0, [x28]
+
+sturb w0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: sturb w0, [x28]
+
+sturh w0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: sturh w0, [x28]
+
+stur w0, [x1]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: stur w0, [x28]
+
+// Byte pre/post-index
+ldrb w0, [x1, #1]!
+// CHECK:      add x1, x1, #1
+// CHECK-NEXT: ldrb w0, [x27, w1, uxtw]
+
+ldrb w0, [x1], #1
+// CHECK:      ldrb w0, [x27, w1, uxtw]
+// CHECK-NEXT: add x1, x1, #1
+
+strb w0, [x1, #1]!
+// CHECK:      add x1, x1, #1
+// CHECK-NEXT: strb w0, [x27, w1, uxtw]
+
+strb w0, [x1], #1
+// CHECK:      strb w0, [x27, w1, uxtw]
+// CHECK-NEXT: add x1, x1, #1
+
+// Halfword pre/post-index
+ldrh w0, [x1, #2]!
+// CHECK:      add x1, x1, #2
+// CHECK-NEXT: ldrh w0, [x27, w1, uxtw]
+
+ldrh w0, [x1], #2
+// CHECK:      ldrh w0, [x27, w1, uxtw]
+// CHECK-NEXT: add x1, x1, #2
+
+// Word pre/post-index
+ldr w0, [x1, #4]!
+// CHECK:      add x1, x1, #4
+// CHECK-NEXT: ldr w0, [x27, w1, uxtw]
+
+ldr w0, [x1], #4
+// CHECK:      ldr w0, [x27, w1, uxtw]
+// CHECK-NEXT: add x1, x1, #4
+
+// Register offset with different sizes
+ldrb w0, [x1, x2]
+// CHECK:      add x26, x1, x2
+// CHECK-NEXT: ldrb w0, [x27, w26, uxtw]
+
+ldrh w0, [x1, x2]
+// CHECK:      add x26, x1, x2
+// CHECK-NEXT: ldrh w0, [x27, w26, uxtw]
+
+ldrh w0, [x1, x2, lsl #1]
+// CHECK:      add x26, x1, x2, lsl #1
+// CHECK-NEXT: ldrh w0, [x27, w26, uxtw]
+
+ldr w0, [x1, x2]
+// CHECK:      add x26, x1, x2
+// CHECK-NEXT: ldr w0, [x27, w26, uxtw]
+
+ldr w0, [x1, x2, lsl #2]
+// CHECK:      add x26, x1, x2, lsl #2
+// CHECK-NEXT: ldr w0, [x27, w26, uxtw]
+
+strb w0, [x1, x2]
+// CHECK:      add x26, x1, x2
+// CHECK-NEXT: strb w0, [x27, w26, uxtw]
+
+strh w0, [x1, x2]
+// CHECK:      add x26, x1, x2
+// CHECK-NEXT: strh w0, [x27, w26, uxtw]
+
+str w0, [x1, x2]
+// CHECK:      add x26, x1, x2
+// CHECK-NEXT: str w0, [x27, w26, uxtw]
+
+str x0, [x1, x2]
+// CHECK:      add x26, x1, x2
+// CHECK-NEXT: str x0, [x27, w26, uxtw]
+
+// Sign/zero extension variants
+ldrb w0, [x1, w2, uxtw]
+// CHECK:      add x26, x1, w2, uxtw
+// CHECK-NEXT: ldrb w0, [x27, w26, uxtw]
+
+ldrb w0, [x1, w2, sxtw]
+// CHECK:      add x26, x1, w2, sxtw
+// CHECK-NEXT: ldrb w0, [x27, w26, uxtw]
+
+ldrh w0, [x1, w2, uxtw]
+// CHECK:      add x26, x1, w2, uxtw
+// CHECK-NEXT: ldrh w0, [x27, w26, uxtw]
+
+ldrh w0, [x1, w2, uxtw #1]
+// CHECK:      add x26, x1, w2, uxtw #1
+// CHECK-NEXT: ldrh w0, [x27, w26, uxtw]
+
+ldr w0, [x1, w2, sxtw #2]
+// CHECK:      add x26, x1, w2, sxtw #2
+// CHECK-NEXT: ldr w0, [x27, w26, uxtw]
+
+// Byte loads with #0 shift (shift amount omitted in output).
+ldrsb x0, [x1, x2, sxtx #0]
+// CHECK:      add x26, x1, x2, sxtx{{$}}
+// CHECK-NEXT: ldrsb x0, [x27, w26, uxtw]
+
+ldrsb w0, [x1, x2, sxtx #0]
+// CHECK:      add x26, x1, x2, sxtx{{$}}
+// CHECK-NEXT: ldrsb w0, [x27, w26, uxtw]
+
+ldrsb w0, [x1, w2, sxtw #0]
+// CHECK:      add x26, x1, w2, sxtw{{$}}
+// CHECK-NEXT: ldrsb w0, [x27, w26, uxtw]
+
+ldrsb x0, [x1, w2, uxtw #0]
+// CHECK:      add x26, x1, w2, uxtw{{$}}
+// CHECK-NEXT: ldrsb x0, [x27, w26, uxtw]
+
+ldrsh x0, [x1, x2, sxtx #1]
+// CHECK:      add x26, x1, x2, sxtx #1
+// CHECK-NEXT: ldrsh x0, [x27, w26, uxtw]
+
+ldrsh w0, [x1, x2, sxtx #1]
+// CHECK:      add x26, x1, x2, sxtx #1
+// CHECK-NEXT: ldrsh w0, [x27, w26, uxtw]
+
+ldrsh w0, [x1, w2, sxtw #1]
+// CHECK:      add x26, x1, w2, sxtw #1
+// CHECK-NEXT: ldrsh w0, [x27, w26, uxtw]
+
+ldrsw x0, [x1, x2, sxtx #2]
+// CHECK:      add x26, x1, x2, sxtx #2
+// CHECK-NEXT: ldrsw x0, [x27, w26, uxtw]
+
+ldrsw x0, [x1, w2, sxtw #2]
+// CHECK:      add x26, x1, w2, sxtw #2
+// CHECK-NEXT: ldrsw x0, [x27, w26, uxtw]
+
+// 32-bit pair pre/post-index
+ldp w0, w1, [x2], #8
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldp w0, w1, [x28]
+// CHECK-NEXT: add x2, x2, #8
+
+ldp w0, w1, [x2, #8]!
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldp w0, w1, [x28, #8]
+// CHECK-NEXT: add x2, x2, #8
+
+stp w0, w1, [x2], #8
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: stp w0, w1, [x28]
+// CHECK-NEXT: add x2, x2, #8
+
+stp w0, w1, [x2, #8]!
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: stp w0, w1, [x28, #8]
+// CHECK-NEXT: add x2, x2, #8
+
+// Memory accesses that define LR (x30) must sandbox the base register
+// in addition to masking LR after the access.
+
+ldr x30, [x0, #0x100]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ldr x30, [x28, #256]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldr x30, [x0]
+// CHECK:      ldr x30, [x27, w0, uxtw]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldr x30, [x0, #8]!
+// CHECK:      add x0, x0, #8
+// CHECK-NEXT: ldr x30, [x27, w0, uxtw]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldr x30, [x0, #-8]!
+// CHECK:      sub x0, x0, #8
+// CHECK-NEXT: ldr x30, [x27, w0, uxtw]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldr x30, [x0], #8
+// CHECK:      ldr x30, [x27, w0, uxtw]
+// CHECK-NEXT: add x0, x0, #8
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldr x30, [x0, x1]
+// CHECK:      add x26, x0, x1
+// CHECK-NEXT: ldr x30, [x27, w26, uxtw]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldr x30, [x0, x1, lsl #3]
+// CHECK:      add x26, x0, x1, lsl #3
+// CHECK-NEXT: ldr x30, [x27, w26, uxtw]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldur x30, [x0, #4]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ldur x30, [x28, #4]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldp x29, x30, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ldp x29, x30, [x28]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldp x29, x30, [x0, #16]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ldp x29, x30, [x28, #16]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldp x29, x30, [x0, #16]!
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ldp x29, x30, [x28, #16]
+// CHECK-NEXT: add x0, x0, #16
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+ldp x29, x30, [x0], #16
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ldp x29, x30, [x28]
+// CHECK-NEXT: add x0, x0, #16
+// CHECK-NEXT: add x30, x27, w30, uxtw
+
+// SP-based LR loads are safe without base sandboxing.
+
+ldr x30, [sp, #16]
+// CHECK:      ldr x30, [sp, #16]
+// CHECK-NEXT: add x30, x27, w30, uxtw

--- a/llvm/test/MC/AArch64/LFI/no-lfi-loads.s
+++ b/llvm/test/MC/AArch64/LFI/no-lfi-loads.s
@@ -1,0 +1,33 @@
+// RUN: llvm-mc -triple aarch64_lfi -mattr=+no-lfi-loads %s | FileCheck %s
+
+// Stores-only mode: loads pass through, stores are sandboxed.
+
+ldr x0, [x1]
+// CHECK: ldr x0, [x1]
+
+ldr x0, [x1, #8]
+// CHECK: ldr x0, [x1, #8]
+
+ldp x0, x1, [x2]
+// CHECK: ldp x0, x1, [x2]
+
+str x0, [x1]
+// CHECK: str x0, [x27, w1, uxtw]
+
+stp x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: stp x0, x1, [x28]
+
+ldr x0, [sp, #8]
+// CHECK: ldr x0, [sp, #8]
+
+str x0, [sp, #8]
+// CHECK: str x0, [sp, #8]
+
+add sp, sp, #8
+// CHECK:      add x26, sp, #8
+// CHECK-NEXT: add sp, x27, w26, uxtw
+
+br x0
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: br x28

--- a/llvm/test/MC/AArch64/LFI/no-lfi-stores.s
+++ b/llvm/test/MC/AArch64/LFI/no-lfi-stores.s
@@ -1,0 +1,35 @@
+// RUN: llvm-mc -triple aarch64_lfi -mattr=+no-lfi-stores %s | FileCheck %s
+
+// Loads-only mode: stores pass through, loads are sandboxed. This
+// configuration is not very useful in practice.
+
+ldr x0, [x1]
+// CHECK: ldr x0, [x27, w1, uxtw]
+
+ldr x0, [x1, #8]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldr x0, [x28, #8]
+
+ldp x0, x1, [x2]
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: ldp x0, x1, [x28]
+
+str x0, [x1]
+// CHECK: str x0, [x1]
+
+stp x0, x1, [x2]
+// CHECK: stp x0, x1, [x2]
+
+ldr x0, [sp, #8]
+// CHECK: ldr x0, [sp, #8]
+
+str x0, [sp, #8]
+// CHECK: str x0, [sp, #8]
+
+add sp, sp, #8
+// CHECK:      add x26, sp, #8
+// CHECK-NEXT: add sp, x27, w26, uxtw
+
+br x0
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: br x28

--- a/llvm/test/MC/AArch64/LFI/prefetch.s
+++ b/llvm/test/MC/AArch64/LFI/prefetch.s
@@ -1,0 +1,81 @@
+// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+
+prfm pldl1keep, [x0]
+// CHECK: prfm pldl1keep, [x27, w0, uxtw]
+
+prfm pldl1strm, [x0]
+// CHECK: prfm pldl1strm, [x27, w0, uxtw]
+
+prfm pldl2keep, [x0]
+// CHECK: prfm pldl2keep, [x27, w0, uxtw]
+
+prfm pldl2strm, [x0]
+// CHECK: prfm pldl2strm, [x27, w0, uxtw]
+
+prfm pldl3keep, [x0]
+// CHECK: prfm pldl3keep, [x27, w0, uxtw]
+
+prfm pldl3strm, [x0]
+// CHECK: prfm pldl3strm, [x27, w0, uxtw]
+
+prfm pstl1keep, [x0]
+// CHECK: prfm pstl1keep, [x27, w0, uxtw]
+
+prfm pstl1strm, [x0]
+// CHECK: prfm pstl1strm, [x27, w0, uxtw]
+
+prfm pstl2keep, [x0]
+// CHECK: prfm pstl2keep, [x27, w0, uxtw]
+
+prfm pstl2strm, [x0]
+// CHECK: prfm pstl2strm, [x27, w0, uxtw]
+
+prfm pldl1keep, [x0, #8]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: prfm pldl1keep, [x28, #8]
+
+prfm pstl1strm, [x0, #16]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: prfm pstl1strm, [x28, #16]
+
+prfm pldl1keep, [x0, x1]
+// CHECK:      add x26, x0, x1
+// CHECK-NEXT: prfm pldl1keep, [x27, w26, uxtw]
+
+prfm pldl1keep, [x0, x1, lsl #3]
+// CHECK:      add x26, x0, x1, lsl #3
+// CHECK-NEXT: prfm pldl1keep, [x27, w26, uxtw]
+
+prfm pldl1keep, [x0, w1, uxtw]
+// CHECK:      add x26, x0, w1, uxtw
+// CHECK-NEXT: prfm pldl1keep, [x27, w26, uxtw]
+
+prfm pldl1keep, [x0, w1, sxtw]
+// CHECK:      add x26, x0, w1, sxtw
+// CHECK-NEXT: prfm pldl1keep, [x27, w26, uxtw]
+
+prfm pldl1keep, [x0, w1, uxtw #3]
+// CHECK:      add x26, x0, w1, uxtw #3
+// CHECK-NEXT: prfm pldl1keep, [x27, w26, uxtw]
+
+prfm pldl1keep, [x0, w1, sxtw #3]
+// CHECK:      add x26, x0, w1, sxtw #3
+// CHECK-NEXT: prfm pldl1keep, [x27, w26, uxtw]
+
+prfum pldl1keep, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: prfum pldl1keep, [x28]
+
+prfum pldl1keep, [x0, #1]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: prfum pldl1keep, [x28, #1]
+
+prfum pstl1strm, [x0, #-8]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: prfum pstl1strm, [x28, #-8]
+
+prfm pldl1keep, [sp]
+// CHECK: prfm pldl1keep, [sp]
+
+prfm pldl1keep, [sp, #8]
+// CHECK: prfm pldl1keep, [sp, #8]

--- a/llvm/test/MC/AArch64/LFI/rcpc.s
+++ b/llvm/test/MC/AArch64/LFI/rcpc.s
@@ -1,0 +1,19 @@
+// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+
+.arch_extension rcpc
+
+ldapr x0, [x8]
+// CHECK:      add x28, x27, w8, uxtw
+// CHECK-NEXT: ldapr x0, [x28]
+
+ldapr w0, [x8]
+// CHECK:      add x28, x27, w8, uxtw
+// CHECK-NEXT: ldapr w0, [x28]
+
+ldaprh w0, [x8]
+// CHECK:      add x28, x27, w8, uxtw
+// CHECK-NEXT: ldaprh w0, [x28]
+
+ldaprb w0, [x8]
+// CHECK:      add x28, x27, w8, uxtw
+// CHECK-NEXT: ldaprb w0, [x28]

--- a/llvm/test/MC/AArch64/LFI/simd.s
+++ b/llvm/test/MC/AArch64/LFI/simd.s
@@ -1,0 +1,650 @@
+// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+
+// LD1/ST1 single structure (no post-index)
+
+ld1 { v0.b }[0], [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1 { v0.b }[0], [x28]
+
+ld1 { v0.h }[1], [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1 { v0.h }[1], [x28]
+
+ld1 { v0.s }[2], [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1 { v0.s }[2], [x28]
+
+ld1 { v0.d }[1], [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1 { v0.d }[1], [x28]
+
+st1 { v0.b }[0], [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st1 { v0.b }[0], [x28]
+
+st1 { v0.h }[1], [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st1 { v0.h }[1], [x28]
+
+st1 { v0.s }[2], [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st1 { v0.s }[2], [x28]
+
+st1 { v0.d }[1], [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st1 { v0.d }[1], [x28]
+
+// LD1/ST1 single structure with post-index (natural offset)
+
+ld1 { v0.b }[0], [x0], #1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1 { v0.b }[0], [x28]
+// CHECK-NEXT: add x0, x0, #1
+
+ld1 { v0.h }[1], [x0], #2
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1 { v0.h }[1], [x28]
+// CHECK-NEXT: add x0, x0, #2
+
+ld1 { v0.s }[2], [x0], #4
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1 { v0.s }[2], [x28]
+// CHECK-NEXT: add x0, x0, #4
+
+ld1 { v0.d }[1], [x0], #8
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1 { v0.d }[1], [x28]
+// CHECK-NEXT: add x0, x0, #8
+
+st1 { v0.b }[0], [x0], #1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st1 { v0.b }[0], [x28]
+// CHECK-NEXT: add x0, x0, #1
+
+st1 { v0.h }[1], [x0], #2
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st1 { v0.h }[1], [x28]
+// CHECK-NEXT: add x0, x0, #2
+
+st1 { v0.s }[2], [x0], #4
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st1 { v0.s }[2], [x28]
+// CHECK-NEXT: add x0, x0, #4
+
+st1 { v0.d }[1], [x0], #8
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st1 { v0.d }[1], [x28]
+// CHECK-NEXT: add x0, x0, #8
+
+// LD1/ST1 single structure with post-index (register offset)
+
+ld1 { v0.b }[0], [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1 { v0.b }[0], [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+ld1 { v0.s }[2], [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1 { v0.s }[2], [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st1 { v0.d }[1], [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st1 { v0.d }[1], [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+// LD1R (replicate single element to all lanes)
+
+ld1r { v0.8b }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1r { v0.8b }, [x28]
+
+ld1r { v0.16b }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1r { v0.16b }, [x28]
+
+ld1r { v0.4h }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1r { v0.4h }, [x28]
+
+ld1r { v0.8h }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1r { v0.8h }, [x28]
+
+ld1r { v0.2s }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1r { v0.2s }, [x28]
+
+ld1r { v0.4s }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1r { v0.4s }, [x28]
+
+ld1r { v0.1d }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1r { v0.1d }, [x28]
+
+ld1r { v0.2d }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1r { v0.2d }, [x28]
+
+// LD1R with post-index
+
+ld1r { v0.8b }, [x0], #1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1r { v0.8b }, [x28]
+// CHECK-NEXT: add x0, x0, #1
+
+ld1r { v0.4h }, [x0], #2
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1r { v0.4h }, [x28]
+// CHECK-NEXT: add x0, x0, #2
+
+ld1r { v0.2s }, [x0], #4
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1r { v0.2s }, [x28]
+// CHECK-NEXT: add x0, x0, #4
+
+ld1r { v0.1d }, [x0], #8
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1r { v0.1d }, [x28]
+// CHECK-NEXT: add x0, x0, #8
+
+ld1r { v0.2d }, [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1r { v0.2d }, [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+// LD1/ST1 multiple structures (1-4 registers)
+
+ld1 { v0.16b }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1 { v0.16b }, [x28]
+
+ld1 { v0.16b, v1.16b }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1 { v0.16b, v1.16b }, [x28]
+
+ld1 { v0.16b, v1.16b, v2.16b }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1 { v0.16b, v1.16b, v2.16b }, [x28]
+
+ld1 { v0.16b, v1.16b, v2.16b, v3.16b }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1 { v0.16b, v1.16b, v2.16b, v3.16b }, [x28]
+
+st1 { v0.16b }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st1 { v0.16b }, [x28]
+
+st1 { v0.16b, v1.16b }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st1 { v0.16b, v1.16b }, [x28]
+
+st1 { v0.16b, v1.16b, v2.16b }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st1 { v0.16b, v1.16b, v2.16b }, [x28]
+
+st1 { v0.16b, v1.16b, v2.16b, v3.16b }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st1 { v0.16b, v1.16b, v2.16b, v3.16b }, [x28]
+
+// LD1/ST1 multiple structures with post-index
+
+ld1 { v0.16b }, [x0], #16
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1 { v0.16b }, [x28]
+// CHECK-NEXT: add x0, x0, #16
+
+ld1 { v0.16b, v1.16b }, [x0], #32
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1 { v0.16b, v1.16b }, [x28]
+// CHECK-NEXT: add x0, x0, #32
+
+ld1 { v0.16b, v1.16b, v2.16b }, [x0], #48
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1 { v0.16b, v1.16b, v2.16b }, [x28]
+// CHECK-NEXT: add x0, x0, #48
+
+ld1 { v0.16b, v1.16b, v2.16b, v3.16b }, [x0], #64
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1 { v0.16b, v1.16b, v2.16b, v3.16b }, [x28]
+// CHECK-NEXT: add x0, x0, #64
+
+ld1 { v0.16b }, [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld1 { v0.16b }, [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+// LD2/ST2 multiple structures
+
+ld2 { v0.8b, v1.8b }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld2 { v0.8b, v1.8b }, [x28]
+
+ld2 { v0.16b, v1.16b }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld2 { v0.16b, v1.16b }, [x28]
+
+ld2 { v0.4h, v1.4h }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld2 { v0.4h, v1.4h }, [x28]
+
+ld2 { v0.8h, v1.8h }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld2 { v0.8h, v1.8h }, [x28]
+
+ld2 { v0.2s, v1.2s }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld2 { v0.2s, v1.2s }, [x28]
+
+ld2 { v0.4s, v1.4s }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld2 { v0.4s, v1.4s }, [x28]
+
+ld2 { v0.2d, v1.2d }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld2 { v0.2d, v1.2d }, [x28]
+
+st2 { v0.16b, v1.16b }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st2 { v0.16b, v1.16b }, [x28]
+
+ld2 { v0.16b, v1.16b }, [x0], #32
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld2 { v0.16b, v1.16b }, [x28]
+// CHECK-NEXT: add x0, x0, #32
+
+st2 { v0.16b, v1.16b }, [x0], #32
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st2 { v0.16b, v1.16b }, [x28]
+// CHECK-NEXT: add x0, x0, #32
+
+// LD3/ST3 multiple structures
+
+ld3 { v0.8b, v1.8b, v2.8b }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld3 { v0.8b, v1.8b, v2.8b }, [x28]
+
+ld3 { v0.16b, v1.16b, v2.16b }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld3 { v0.16b, v1.16b, v2.16b }, [x28]
+
+ld3 { v0.4s, v1.4s, v2.4s }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld3 { v0.4s, v1.4s, v2.4s }, [x28]
+
+st3 { v0.4s, v1.4s, v2.4s }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st3 { v0.4s, v1.4s, v2.4s }, [x28]
+
+ld3 { v0.4s, v1.4s, v2.4s }, [x0], #48
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld3 { v0.4s, v1.4s, v2.4s }, [x28]
+// CHECK-NEXT: add x0, x0, #48
+
+ld3 { v0.4s, v1.4s, v2.4s }, [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld3 { v0.4s, v1.4s, v2.4s }, [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+// LD4/ST4 multiple structures
+
+ld4 { v0.8b, v1.8b, v2.8b, v3.8b }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld4 { v0.8b, v1.8b, v2.8b, v3.8b }, [x28]
+
+ld4 { v0.16b, v1.16b, v2.16b, v3.16b }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld4 { v0.16b, v1.16b, v2.16b, v3.16b }, [x28]
+
+ld4 { v0.4s, v1.4s, v2.4s, v3.4s }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld4 { v0.4s, v1.4s, v2.4s, v3.4s }, [x28]
+
+ld4 { v0.2d, v1.2d, v2.2d, v3.2d }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld4 { v0.2d, v1.2d, v2.2d, v3.2d }, [x28]
+
+st4 { v0.4s, v1.4s, v2.4s, v3.4s }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st4 { v0.4s, v1.4s, v2.4s, v3.4s }, [x28]
+
+ld4 { v0.4s, v1.4s, v2.4s, v3.4s }, [x0], #64
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld4 { v0.4s, v1.4s, v2.4s, v3.4s }, [x28]
+// CHECK-NEXT: add x0, x0, #64
+
+ld4 { v0.4s, v1.4s, v2.4s, v3.4s }, [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld4 { v0.4s, v1.4s, v2.4s, v3.4s }, [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+// LD2R/LD3R/LD4R (replicate)
+
+ld2r { v0.8b, v1.8b }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld2r { v0.8b, v1.8b }, [x28]
+
+ld3r { v0.4s, v1.4s, v2.4s }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld3r { v0.4s, v1.4s, v2.4s }, [x28]
+
+ld4r { v0.2d, v1.2d, v2.2d, v3.2d }, [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld4r { v0.2d, v1.2d, v2.2d, v3.2d }, [x28]
+
+ld2r { v0.8b, v1.8b }, [x0], #2
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld2r { v0.8b, v1.8b }, [x28]
+// CHECK-NEXT: add x0, x0, #2
+
+ld3r { v0.4s, v1.4s, v2.4s }, [x0], #12
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld3r { v0.4s, v1.4s, v2.4s }, [x28]
+// CHECK-NEXT: add x0, x0, #12
+
+ld4r { v0.2d, v1.2d, v2.2d, v3.2d }, [x0], #32
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld4r { v0.2d, v1.2d, v2.2d, v3.2d }, [x28]
+// CHECK-NEXT: add x0, x0, #32
+
+// LD2/LD3/LD4 single structure (lane loads)
+
+ld2 { v0.b, v1.b }[0], [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld2 { v0.b, v1.b }[0], [x28]
+
+ld3 { v0.s, v1.s, v2.s }[1], [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld3 { v0.s, v1.s, v2.s }[1], [x28]
+
+ld4 { v0.d, v1.d, v2.d, v3.d }[0], [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld4 { v0.d, v1.d, v2.d, v3.d }[0], [x28]
+
+st2 { v0.h, v1.h }[3], [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st2 { v0.h, v1.h }[3], [x28]
+
+st3 { v0.s, v1.s, v2.s }[2], [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st3 { v0.s, v1.s, v2.s }[2], [x28]
+
+st4 { v0.d, v1.d, v2.d, v3.d }[1], [x0]
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st4 { v0.d, v1.d, v2.d, v3.d }[1], [x28]
+
+ld2 { v0.b, v1.b }[0], [x0], #2
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld2 { v0.b, v1.b }[0], [x28]
+// CHECK-NEXT: add x0, x0, #2
+
+ld3 { v0.s, v1.s, v2.s }[1], [x0], #12
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld3 { v0.s, v1.s, v2.s }[1], [x28]
+// CHECK-NEXT: add x0, x0, #12
+
+ld4 { v0.d, v1.d, v2.d, v3.d }[0], [x0], #32
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld4 { v0.d, v1.d, v2.d, v3.d }[0], [x28]
+// CHECK-NEXT: add x0, x0, #32
+
+ld2 { v0.s, v1.s }[1], [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld2 { v0.s, v1.s }[1], [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+// ST2/ST3/ST4 lane stores with immediate post-index
+
+st2 { v0.b, v1.b }[0], [x0], #2
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st2 { v0.b, v1.b }[0], [x28]
+// CHECK-NEXT: add x0, x0, #2
+
+st2 { v0.h, v1.h }[1], [x0], #4
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st2 { v0.h, v1.h }[1], [x28]
+// CHECK-NEXT: add x0, x0, #4
+
+st2 { v0.s, v1.s }[2], [x0], #8
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st2 { v0.s, v1.s }[2], [x28]
+// CHECK-NEXT: add x0, x0, #8
+
+st2 { v0.d, v1.d }[1], [x0], #16
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st2 { v0.d, v1.d }[1], [x28]
+// CHECK-NEXT: add x0, x0, #16
+
+st3 { v0.b, v1.b, v2.b }[0], [x0], #3
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st3 { v0.b, v1.b, v2.b }[0], [x28]
+// CHECK-NEXT: add x0, x0, #3
+
+st3 { v0.h, v1.h, v2.h }[1], [x0], #6
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st3 { v0.h, v1.h, v2.h }[1], [x28]
+// CHECK-NEXT: add x0, x0, #6
+
+st3 { v0.s, v1.s, v2.s }[2], [x0], #12
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st3 { v0.s, v1.s, v2.s }[2], [x28]
+// CHECK-NEXT: add x0, x0, #12
+
+st3 { v0.d, v1.d, v2.d }[0], [x0], #24
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st3 { v0.d, v1.d, v2.d }[0], [x28]
+// CHECK-NEXT: add x0, x0, #24
+
+st4 { v0.b, v1.b, v2.b, v3.b }[0], [x0], #4
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st4 { v0.b, v1.b, v2.b, v3.b }[0], [x28]
+// CHECK-NEXT: add x0, x0, #4
+
+st4 { v0.h, v1.h, v2.h, v3.h }[1], [x0], #8
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st4 { v0.h, v1.h, v2.h, v3.h }[1], [x28]
+// CHECK-NEXT: add x0, x0, #8
+
+st4 { v0.s, v1.s, v2.s, v3.s }[2], [x0], #16
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st4 { v0.s, v1.s, v2.s, v3.s }[2], [x28]
+// CHECK-NEXT: add x0, x0, #16
+
+st4 { v0.d, v1.d, v2.d, v3.d }[0], [x0], #32
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st4 { v0.d, v1.d, v2.d, v3.d }[0], [x28]
+// CHECK-NEXT: add x0, x0, #32
+
+// ST1/ST2/ST3/ST4 lane stores with register post-index
+
+st1 { v0.b }[0], [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st1 { v0.b }[0], [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st1 { v0.h }[1], [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st1 { v0.h }[1], [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st1 { v0.s }[2], [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st1 { v0.s }[2], [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st2 { v0.b, v1.b }[0], [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st2 { v0.b, v1.b }[0], [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st2 { v0.s, v1.s }[1], [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st2 { v0.s, v1.s }[1], [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st2 { v0.d, v1.d }[0], [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st2 { v0.d, v1.d }[0], [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st3 { v0.b, v1.b, v2.b }[0], [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st3 { v0.b, v1.b, v2.b }[0], [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st3 { v0.s, v1.s, v2.s }[1], [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st3 { v0.s, v1.s, v2.s }[1], [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st3 { v0.d, v1.d, v2.d }[0], [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st3 { v0.d, v1.d, v2.d }[0], [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st4 { v0.b, v1.b, v2.b, v3.b }[0], [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st4 { v0.b, v1.b, v2.b, v3.b }[0], [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st4 { v0.s, v1.s, v2.s, v3.s }[1], [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st4 { v0.s, v1.s, v2.s, v3.s }[1], [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st4 { v0.d, v1.d, v2.d, v3.d }[0], [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st4 { v0.d, v1.d, v2.d, v3.d }[0], [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+ld3 { v0.b, v1.b, v2.b }[0], [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld3 { v0.b, v1.b, v2.b }[0], [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+ld3 { v0.d, v1.d, v2.d }[0], [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld3 { v0.d, v1.d, v2.d }[0], [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+ld4 { v0.b, v1.b, v2.b, v3.b }[0], [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld4 { v0.b, v1.b, v2.b, v3.b }[0], [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+ld4 { v0.s, v1.s, v2.s, v3.s }[1], [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld4 { v0.s, v1.s, v2.s, v3.s }[1], [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+// ST1/ST2/ST3/ST4 multi-register stores with register post-index
+
+st1 { v0.16b }, [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st1 { v0.16b }, [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st1 { v0.16b, v1.16b }, [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st1 { v0.16b, v1.16b }, [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st1 { v0.16b, v1.16b, v2.16b }, [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st1 { v0.16b, v1.16b, v2.16b }, [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st1 { v0.16b, v1.16b, v2.16b, v3.16b }, [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st1 { v0.16b, v1.16b, v2.16b, v3.16b }, [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st2 { v0.16b, v1.16b }, [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st2 { v0.16b, v1.16b }, [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st2 { v0.4s, v1.4s }, [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st2 { v0.4s, v1.4s }, [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st3 { v0.16b, v1.16b, v2.16b }, [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st3 { v0.16b, v1.16b, v2.16b }, [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st3 { v0.4s, v1.4s, v2.4s }, [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st3 { v0.4s, v1.4s, v2.4s }, [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st4 { v0.16b, v1.16b, v2.16b, v3.16b }, [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st4 { v0.16b, v1.16b, v2.16b, v3.16b }, [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st4 { v0.4s, v1.4s, v2.4s, v3.4s }, [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st4 { v0.4s, v1.4s, v2.4s, v3.4s }, [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+st4 { v0.2d, v1.2d, v2.2d, v3.2d }, [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: st4 { v0.2d, v1.2d, v2.2d, v3.2d }, [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+ld2 { v0.16b, v1.16b }, [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld2 { v0.16b, v1.16b }, [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+ld2 { v0.4s, v1.4s }, [x0], x1
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ld2 { v0.4s, v1.4s }, [x28]
+// CHECK-NEXT: add x0, x0, x1
+
+// SIMD post-index with SP base.
+
+ld1 { v0.16b }, [sp], #16
+// CHECK: ld1 { v0.16b }, [sp], #16
+
+ld1 { v0.16b }, [sp], x1
+// CHECK:      ld1 { v0.16b }, [sp]
+// CHECK-NEXT: add x26, sp, x1
+// CHECK-NEXT: add sp, x27, w26, uxtw
+
+st1 { v0.16b }, [sp], #16
+// CHECK: st1 { v0.16b }, [sp], #16
+
+st1 { v0.16b }, [sp], x1
+// CHECK:      st1 { v0.16b }, [sp]
+// CHECK-NEXT: add x26, sp, x1
+// CHECK-NEXT: add sp, x27, w26, uxtw
+
+ld2 { v0.16b, v1.16b }, [sp], #32
+// CHECK: ld2 { v0.16b, v1.16b }, [sp], #32
+
+ld2 { v0.16b, v1.16b }, [sp], x2
+// CHECK:      ld2 { v0.16b, v1.16b }, [sp]
+// CHECK-NEXT: add x26, sp, x2
+// CHECK-NEXT: add sp, x27, w26, uxtw
+
+st4 { v0.4s, v1.4s, v2.4s, v3.4s }, [sp], x1
+// CHECK:      st4 { v0.4s, v1.4s, v2.4s, v3.4s }, [sp]
+// CHECK-NEXT: add x26, sp, x1
+// CHECK-NEXT: add sp, x27, w26, uxtw
+
+ld1 { v0.b }[0], [sp], #1
+// CHECK: ld1 { v0.b }[0], [sp], #1
+
+ld1 { v0.b }[0], [sp], x1
+// CHECK:      ld1 { v0.b }[0], [sp]
+// CHECK-NEXT: add x26, sp, x1
+// CHECK-NEXT: add sp, x27, w26, uxtw
+
+st1 { v0.s }[2], [sp], x1
+// CHECK:      st1 { v0.s }[2], [sp]
+// CHECK-NEXT: add x26, sp, x1
+// CHECK-NEXT: add sp, x27, w26, uxtw

--- a/llvm/test/MC/AArch64/LFI/stack.s
+++ b/llvm/test/MC/AArch64/LFI/stack.s
@@ -36,6 +36,7 @@ sub sp, sp, #1, lsl #12
 // CHECK:      sub x26, sp, #1, lsl #12
 // CHECK-NEXT: add sp, x27, w26, uxtw
 
+// SP-based load that defines LR (x30) still needs LR sandboxed after the load.
 ldp x29, x30, [sp], #16
 // CHECK:      ldp x29, x30, [sp], #16
 // CHECK-NEXT: add x30, x27, w30, uxtw

--- a/llvm/test/MC/AArch64/LFI/stack.s
+++ b/llvm/test/MC/AArch64/LFI/stack.s
@@ -13,8 +13,7 @@ str x0, [sp], #16
 // CHECK: str x0, [sp], #16
 
 mov sp, x0
-// CHECK:      add x26, x0, #0
-// CHECK-NEXT: add sp, x27, w26, uxtw
+// CHECK: add sp, x27, w0, uxtw
 
 add sp, sp, #8
 // CHECK:      add x26, sp, #8

--- a/llvm/test/MC/AArch64/LFI/stack.s
+++ b/llvm/test/MC/AArch64/LFI/stack.s
@@ -1,0 +1,41 @@
+// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+
+ldr x0, [sp, #16]!
+// CHECK: ldr x0, [sp, #16]!
+
+ldr x0, [sp], #16
+// CHECK: ldr x0, [sp], #16
+
+str x0, [sp, #16]!
+// CHECK: str x0, [sp, #16]!
+
+str x0, [sp], #16
+// CHECK: str x0, [sp], #16
+
+mov sp, x0
+// CHECK:      add x26, x0, #0
+// CHECK-NEXT: add sp, x27, w26, uxtw
+
+add sp, sp, #8
+// CHECK:      add x26, sp, #8
+// CHECK-NEXT: add sp, x27, w26, uxtw
+
+sub sp, sp, #8
+// CHECK:      sub x26, sp, #8
+// CHECK-NEXT: add sp, x27, w26, uxtw
+
+add sp, sp, x0
+// CHECK:      add x26, sp, x0
+// CHECK-NEXT: add sp, x27, w26, uxtw
+
+sub sp, sp, x0
+// CHECK:      sub x26, sp, x0
+// CHECK-NEXT: add sp, x27, w26, uxtw
+
+sub sp, sp, #1, lsl #12
+// CHECK:      sub x26, sp, #1, lsl #12
+// CHECK-NEXT: add sp, x27, w26, uxtw
+
+ldp x29, x30, [sp], #16
+// CHECK:      ldp x29, x30, [sp], #16
+// CHECK-NEXT: add x30, x27, w30, uxtw

--- a/llvm/test/MC/AArch64/LFI/sys.s
+++ b/llvm/test/MC/AArch64/LFI/sys.s
@@ -5,3 +5,27 @@ svc #0
 // CHECK-NEXT: ldur x30, [x27, #-8]
 // CHECK-NEXT: blr x30
 // CHECK-NEXT: add x30, x27, w26, uxtw
+
+dc zva, x0
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: dc zva, x28
+
+dc zva, x5
+// CHECK:      add x28, x27, w5, uxtw
+// CHECK-NEXT: dc zva, x28
+
+dc cvac, x0
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: dc cvac, x28
+
+dc cvau, x1
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: dc cvau, x28
+
+dc civac, x2
+// CHECK:      add x28, x27, w2, uxtw
+// CHECK-NEXT: dc civac, x28
+
+ic ivau, x4
+// CHECK:      add x28, x27, w4, uxtw
+// CHECK-NEXT: ic ivau, x28


### PR DESCRIPTION
Refactor AArch64 Lightweight Fault Isolation(LFI) metadata TableGen architecture
to automate scalar variant and SIMD post-index mappings.

This approach improves upon the previous design by centralizing all
suffix-to-base instruction conversions into a single, unified
LFIScalarVariant helper class. This eliminates the need for scattered,
multiclass-specific string substitutions. Furthermore, size and scale
checks have been fully prefixed (e.g., matching LDR/STR or LDP/STP
structures), resolving previous prefix collisions where doubleword
instructions were incorrectly classified.

- Move LFI-specific TableGen classes into a dedicated, isolated target file:
  AArch64LFIInstrFormats.td.
- Introduce a unified LFIScalarVariant base class that dynamically resolves
  an instruction's addressing mode (AddrMode) and base register-offset
  instruction (RoWInst) at TableGen compile-time.
- Centralize the LFIInst instruction cast inside LFIInstruction to simplify
  LFIInst definitions across all subclasses.
- Automate SIMD post-index writeback scaling via TableGen, removing over 200
  lines of manual foreach mapping loops in AArch64LFI.td.
- Maintain a clean separation of concerns, leaving AArch64InstrFormats.td
  focused strictly on core memory layout properties for the MemInfoTable.
- Synchronize structure fields in AArch64MCLFIRewriter.cpp with TableGen's
  generated searchable primary keys.
